### PR TITLE
feat(security): implement Fast Path for DoS protection in TransportComponent

### DIFF
--- a/Tests/FastPathTests.cs
+++ b/Tests/FastPathTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Buffers;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using Ubicomp.Utils.NET.MulticastTransportFramework;
+using Ubicomp.Utils.NET.Sockets;
+using Xunit;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace Ubicomp.Utils.NET.Tests
+{
+    public class FastPathTests
+    {
+        public class TestLogger : ILogger, IDisposable
+        {
+            public List<string> Logs { get; } = new List<string>();
+
+            public IDisposable BeginScope<TState>(TState state) => this;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Logs.Add(formatter(state, exception));
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        [MessageType("test.fastpath")]
+        public class FastPathMessage
+        {
+            public string Data { get; set; }
+        }
+
+        [Fact]
+        public void TestFastPath_ValidMessage_Processed()
+        {
+            var options = MulticastSocketOptions.LocalNetwork();
+            var transport = new TransportComponent(options);
+            var logger = new TestLogger();
+            transport.Logger = logger;
+
+            bool handled = false;
+            transport.RegisterHandler<FastPathMessage>((msg, ctx) =>
+            {
+                handled = true;
+            });
+
+            var source = new EventSource(Guid.NewGuid(), "TestSender");
+            var payload = new FastPathMessage { Data = "Valid" };
+            var tMsg = new TransportMessage(source, "test.fastpath", payload);
+            // Ensure valid timestamp
+            tMsg.TimeStamp = DateTime.UtcNow.ToString(TransportMessage.DATE_FORMAT_NOW);
+
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNameCaseInsensitive = true
+            };
+            var json = JsonSerializer.Serialize(tMsg, jsonOptions);
+            var bytes = Encoding.UTF8.GetBytes(json);
+
+            var socketMsg = new SocketMessage(bytes, 1);
+
+            var processMethod = typeof(TransportComponent).GetMethod("ProcessSingleMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+            processMethod.Invoke(transport, new object[] { socketMsg });
+
+            Assert.True(handled, "Message should be handled");
+        }
+
+        [Fact]
+        public void TestFastPath_InvalidTimestamp_Dropped()
+        {
+            var options = MulticastSocketOptions.LocalNetwork();
+            var transport = new TransportComponent(options);
+            var logger = new TestLogger();
+            transport.Logger = logger;
+
+            bool handled = false;
+            transport.RegisterHandler<FastPathMessage>((msg, ctx) =>
+            {
+                handled = true;
+            });
+
+            var source = new EventSource(Guid.NewGuid(), "TestSender");
+            var payload = new FastPathMessage { Data = "InvalidTimestamp" };
+            var tMsg = new TransportMessage(source, "test.fastpath", payload);
+            // Set OLD timestamp
+            tMsg.TimeStamp = DateTime.UtcNow.AddHours(-1).ToString(TransportMessage.DATE_FORMAT_NOW);
+
+            var jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNameCaseInsensitive = true
+            };
+            var json = JsonSerializer.Serialize(tMsg, jsonOptions);
+            var bytes = Encoding.UTF8.GetBytes(json);
+
+            var socketMsg = new SocketMessage(bytes, 1);
+
+            var processMethod = typeof(TransportComponent).GetMethod("ProcessSingleMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+            processMethod.Invoke(transport, new object[] { socketMsg });
+
+            Assert.False(handled, "Message with old timestamp should be dropped");
+            Assert.Contains(logger.Logs, l => l.Contains("timestamp out of bounds (FastPath)"));
+        }
+
+        [Fact]
+        public void TestFastPath_MalformedHeader_Dropped()
+        {
+            var options = MulticastSocketOptions.LocalNetwork();
+            var transport = new TransportComponent(options);
+            var logger = new TestLogger();
+            transport.Logger = logger;
+
+            bool handled = false;
+            transport.RegisterHandler<FastPathMessage>((msg, ctx) =>
+            {
+                handled = true;
+            });
+
+            // JSON missing MessageId
+            var json = @"{ ""timeStamp"": ""2023-01-01 00:00:00"", ""messageType"": ""test.fastpath"", ""messageData"": { ""data"": ""Bad"" } }";
+            var bytes = Encoding.UTF8.GetBytes(json);
+
+            var socketMsg = new SocketMessage(bytes, 1);
+
+            var processMethod = typeof(TransportComponent).GetMethod("ProcessSingleMessage", BindingFlags.NonPublic | BindingFlags.Instance);
+            processMethod.Invoke(transport, new object[] { socketMsg });
+
+            Assert.False(handled, "Message without MessageId should be dropped");
+            // Expect "Dropped malformed message" or similar from FastPath failure
+            Assert.Contains(logger.Logs, l => l.Contains("FastPath failed to read header"));
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel Security Enhancement: DoS Protection via Fast Path

**Vulnerability:**
Previously, `TransportComponent` would fully deserialize incoming JSON messages (including potentially large payloads) before checking if the message was a replay or expired. An attacker could flood the system with large, valid JSON messages that are replays, consuming CPU and memory for deserialization before the messages are discarded.

**Fix:**
Implemented a "Fast Path" mechanism that uses `System.Text.Json.Utf8JsonReader` to scan the raw byte buffer for `MessageId` and `TimeStamp` properties.

1.  **Early Rejection:** Messages with invalid timestamps or those found in the replay cache are dropped *before* string allocation and full object deserialization.
2.  **Zero-Allocation Scanning:** The `Utf8JsonReader` operates on `ReadOnlySpan<byte>`, minimizing GC pressure.
3.  **Refactored Replay Logic:** Centralized replay protection logic (cache limits, logging, atomic addition) into `TryRegisterMessage` for consistency.

**Verification:**
- Added `Tests/FastPathTests.cs` verifying that:
    - Valid messages are processed correctly.
    - Messages with invalid timestamps are dropped without processing.
    - Malformed messages (missing headers) are dropped.
- Verified existing `ReplayAttackTests` still pass.
- Validated that the fast path correctly updates the replay cache, preventing the slow path from processing the same message.

**Impact:**
significantly reduces CPU usage under Replay/DoS attack conditions by rejecting bad traffic early in the pipeline.

---
*PR created automatically by Jules for task [18271988084288546](https://jules.google.com/task/18271988084288546) started by @jhincapie*