### PR TITLE
⚡ Bolt: Optimize BinaryPacket serialization allocation

### DIFF
--- a/benchmark_baseline.txt
+++ b/benchmark_baseline.txt
@@ -1,21 +1,21 @@
-/app/Benchmarks/BinaryPacketBenchmark.cs(14,39): warning CS8618: Non-nullable field '_jsonOptions' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
-/app/Benchmarks/BinaryPacketBenchmark.cs(15,56): warning CS8618: Non-nullable field '_writer' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
-/app/Benchmarks/BinaryPacketBenchmark.cs(16,24): warning CS8618: Non-nullable field '_integrityKey' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
-/app/Benchmarks/BinaryPacketBenchmark.cs(17,24): warning CS8618: Non-nullable field '_serializedWithIntegrity' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 /app/Benchmarks/SerializationBenchmark.cs(14,24): warning CS8618: Non-nullable field '_jsonNewtonsoft' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 /app/Benchmarks/SerializationBenchmark.cs(15,24): warning CS8618: Non-nullable field '_jsonSystemText' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 /app/Benchmarks/SerializationBenchmark.cs(16,40): warning CS8618: Non-nullable field '_newtonsoftSettings' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 /app/Benchmarks/SerializationBenchmark.cs(17,39): warning CS8618: Non-nullable field '_systemTextOptions' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 /app/Benchmarks/SerializationBenchmark.cs(18,42): warning CS8618: Non-nullable field '_knownTypes' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(14,39): warning CS8618: Non-nullable field '_jsonOptions' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(15,56): warning CS8618: Non-nullable field '_writer' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(16,24): warning CS8618: Non-nullable field '_integrityKey' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(17,24): warning CS8618: Non-nullable field '_serializedWithIntegrity' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
 // Validating benchmarks:
 // ***** BenchmarkRunner: Start   *****
 // ***** Found 3 benchmark(s) in total *****
 // ***** Building 1 exe(s) in Parallel: Start   *****
-// start dotnet  restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/229109e4-4bb7-47a2-826d-d98e7b43645d
-// command took 3.03 sec and exited with 0
-// start dotnet  build -c Release --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/229109e4-4bb7-47a2-826d-d98e7b43645d
-// command took 6.87 sec and exited with 0
-// ***** Done, took 00:00:10 (10.31 sec)   *****
+// start dotnet  restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/dc873c13-f40c-478c-b885-f641d4254d14
+// command took 3.25 sec and exited with 0
+// start dotnet  build -c Release --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/dc873c13-f40c-478c-b885-f641d4254d14
+// command took 7.15 sec and exited with 0
+// ***** Done, took 00:00:10 (10.82 sec)   *****
 // Found 3 benchmarks:
 //   BinaryPacketBenchmark.SerializeToWriter: DefaultJob
 //   BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
@@ -25,7 +25,7 @@
 // Benchmark: BinaryPacketBenchmark.SerializeToWriter: DefaultJob
 // *** Execute ***
 // Launch: 1 / 1
-// Execute: dotnet 229109e4-4bb7-47a2-826d-d98e7b43645d.dll --anonymousPipes 117 118 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeToWriter --job Default --benchmarkId 0 in /app/Benchmarks/bin/Release/net8.0/229109e4-4bb7-47a2-826d-d98e7b43645d/bin/Release/net8.0
+// Execute: dotnet dc873c13-f40c-478c-b885-f641d4254d14.dll --anonymousPipes 117 118 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeToWriter --job Default --benchmarkId 0 in /app/Benchmarks/bin/Release/net8.0/dc873c13-f40c-478c-b885-f641d4254d14/bin/Release/net8.0
 // Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
 // BeforeAnythingElse
 
@@ -36,124 +36,114 @@
 // HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
 // Job: DefaultJob
 
-OverheadJitting  1: 1 op, 359662.00 ns, 359.6620 us/op
-WorkloadJitting  1: 1 op, 651073.00 ns, 651.0730 us/op
+OverheadJitting  1: 1 op, 410973.00 ns, 410.9730 us/op
+WorkloadJitting  1: 1 op, 670241.00 ns, 670.2410 us/op
 
-OverheadJitting  2: 16 op, 350415.00 ns, 21.9009 us/op
-WorkloadJitting  2: 16 op, 516454.00 ns, 32.2784 us/op
+OverheadJitting  2: 16 op, 291037.00 ns, 18.1898 us/op
+WorkloadJitting  2: 16 op, 545387.00 ns, 34.0867 us/op
 
-WorkloadPilot    1: 16 op, 101088.00 ns, 6.3180 us/op
-WorkloadPilot    2: 32 op, 138974.00 ns, 4.3429 us/op
-WorkloadPilot    3: 64 op, 232373.00 ns, 3.6308 us/op
-WorkloadPilot    4: 128 op, 549767.00 ns, 4.2951 us/op
-WorkloadPilot    5: 256 op, 875953.00 ns, 3.4217 us/op
-WorkloadPilot    6: 512 op, 1794445.00 ns, 3.5048 us/op
-WorkloadPilot    7: 1024 op, 3322362.00 ns, 3.2445 us/op
-WorkloadPilot    8: 2048 op, 6700681.00 ns, 3.2718 us/op
-WorkloadPilot    9: 4096 op, 13468754.00 ns, 3.2883 us/op
-WorkloadPilot   10: 8192 op, 27156222.00 ns, 3.3150 us/op
-WorkloadPilot   11: 16384 op, 53811984.00 ns, 3.2844 us/op
-WorkloadPilot   12: 32768 op, 159785863.00 ns, 4.8763 us/op
-WorkloadPilot   13: 65536 op, 292435549.00 ns, 4.4622 us/op
-WorkloadPilot   14: 131072 op, 136130787.00 ns, 1.0386 us/op
-WorkloadPilot   15: 262144 op, 271033207.00 ns, 1.0339 us/op
-WorkloadPilot   16: 524288 op, 541346517.00 ns, 1.0325 us/op
+WorkloadPilot    1: 16 op, 103016.00 ns, 6.4385 us/op
+WorkloadPilot    2: 32 op, 136475.00 ns, 4.2648 us/op
+WorkloadPilot    3: 64 op, 322339.00 ns, 5.0365 us/op
+WorkloadPilot    4: 128 op, 459795.00 ns, 3.5921 us/op
+WorkloadPilot    5: 256 op, 929546.00 ns, 3.6310 us/op
+WorkloadPilot    6: 512 op, 1710296.00 ns, 3.3404 us/op
+WorkloadPilot    7: 1024 op, 3265507.00 ns, 3.1890 us/op
+WorkloadPilot    8: 2048 op, 6661970.00 ns, 3.2529 us/op
+WorkloadPilot    9: 4096 op, 13133101.00 ns, 3.2063 us/op
+WorkloadPilot   10: 8192 op, 26430885.00 ns, 3.2264 us/op
+WorkloadPilot   11: 16384 op, 52494258.00 ns, 3.2040 us/op
+WorkloadPilot   12: 32768 op, 145481880.00 ns, 4.4398 us/op
+WorkloadPilot   13: 65536 op, 253714796.00 ns, 3.8714 us/op
+WorkloadPilot   14: 131072 op, 133698083.00 ns, 1.0200 us/op
+WorkloadPilot   15: 262144 op, 265321431.00 ns, 1.0121 us/op
+WorkloadPilot   16: 524288 op, 530384618.00 ns, 1.0116 us/op
 
-OverheadWarmup   1: 524288 op, 1644859.00 ns, 3.1373 ns/op
-OverheadWarmup   2: 524288 op, 1664483.00 ns, 3.1747 ns/op
-OverheadWarmup   3: 524288 op, 1695032.00 ns, 3.2330 ns/op
-OverheadWarmup   4: 524288 op, 1748347.00 ns, 3.3347 ns/op
-OverheadWarmup   5: 524288 op, 1706437.00 ns, 3.2548 ns/op
-OverheadWarmup   6: 524288 op, 1667855.00 ns, 3.1812 ns/op
-OverheadWarmup   7: 524288 op, 1670470.00 ns, 3.1862 ns/op
-OverheadWarmup   8: 524288 op, 1671872.00 ns, 3.1888 ns/op
-OverheadWarmup   9: 524288 op, 1720921.00 ns, 3.2824 ns/op
-OverheadWarmup  10: 524288 op, 1717969.00 ns, 3.2768 ns/op
+OverheadWarmup   1: 524288 op, 1688192.00 ns, 3.2200 ns/op
+OverheadWarmup   2: 524288 op, 1669224.00 ns, 3.1838 ns/op
+OverheadWarmup   3: 524288 op, 1687576.00 ns, 3.2188 ns/op
+OverheadWarmup   4: 524288 op, 1694310.00 ns, 3.2316 ns/op
+OverheadWarmup   5: 524288 op, 1755360.00 ns, 3.3481 ns/op
+OverheadWarmup   6: 524288 op, 1697667.00 ns, 3.2380 ns/op
+OverheadWarmup   7: 524288 op, 1680843.00 ns, 3.2060 ns/op
+OverheadWarmup   8: 524288 op, 1666177.00 ns, 3.1780 ns/op
+OverheadWarmup   9: 524288 op, 1720242.00 ns, 3.2811 ns/op
+OverheadWarmup  10: 524288 op, 1731601.00 ns, 3.3028 ns/op
 
-OverheadActual   1: 524288 op, 1783961.00 ns, 3.4026 ns/op
-OverheadActual   2: 524288 op, 1671160.00 ns, 3.1875 ns/op
-OverheadActual   3: 524288 op, 1678091.00 ns, 3.2007 ns/op
-OverheadActual   4: 524288 op, 1675932.00 ns, 3.1966 ns/op
-OverheadActual   5: 524288 op, 1724697.00 ns, 3.2896 ns/op
-OverheadActual   6: 524288 op, 1721582.00 ns, 3.2837 ns/op
-OverheadActual   7: 524288 op, 1649707.00 ns, 3.1466 ns/op
-OverheadActual   8: 524288 op, 1641426.00 ns, 3.1308 ns/op
-OverheadActual   9: 524288 op, 1730618.00 ns, 3.3009 ns/op
-OverheadActual  10: 524288 op, 1713704.00 ns, 3.2686 ns/op
-OverheadActual  11: 524288 op, 1684732.00 ns, 3.2134 ns/op
-OverheadActual  12: 524288 op, 1695369.00 ns, 3.2337 ns/op
-OverheadActual  13: 524288 op, 1674296.00 ns, 3.1935 ns/op
-OverheadActual  14: 524288 op, 1687208.00 ns, 3.2181 ns/op
-OverheadActual  15: 524288 op, 1673826.00 ns, 3.1926 ns/op
+OverheadActual   1: 524288 op, 1788348.00 ns, 3.4110 ns/op
+OverheadActual   2: 524288 op, 1690374.00 ns, 3.2241 ns/op
+OverheadActual   3: 524288 op, 1724485.00 ns, 3.2892 ns/op
+OverheadActual   4: 524288 op, 1718942.00 ns, 3.2786 ns/op
+OverheadActual   5: 524288 op, 1643321.00 ns, 3.1344 ns/op
+OverheadActual   6: 524288 op, 1684862.00 ns, 3.2136 ns/op
+OverheadActual   7: 524288 op, 1765564.00 ns, 3.3675 ns/op
+OverheadActual   8: 524288 op, 1664160.00 ns, 3.1741 ns/op
+OverheadActual   9: 524288 op, 1669521.00 ns, 3.1844 ns/op
+OverheadActual  10: 524288 op, 1723499.00 ns, 3.2873 ns/op
+OverheadActual  11: 524288 op, 1748638.00 ns, 3.3353 ns/op
+OverheadActual  12: 524288 op, 1677379.00 ns, 3.1993 ns/op
+OverheadActual  13: 524288 op, 1703905.00 ns, 3.2499 ns/op
+OverheadActual  14: 524288 op, 1795068.00 ns, 3.4238 ns/op
+OverheadActual  15: 524288 op, 1675355.00 ns, 3.1955 ns/op
 
-WorkloadWarmup   1: 524288 op, 555650802.00 ns, 1.0598 us/op
-WorkloadWarmup   2: 524288 op, 608148325.00 ns, 1.1600 us/op
-WorkloadWarmup   3: 524288 op, 550278215.00 ns, 1.0496 us/op
-WorkloadWarmup   4: 524288 op, 544241647.00 ns, 1.0381 us/op
-WorkloadWarmup   5: 524288 op, 539871850.00 ns, 1.0297 us/op
-WorkloadWarmup   6: 524288 op, 541170953.00 ns, 1.0322 us/op
-WorkloadWarmup   7: 524288 op, 567814926.00 ns, 1.0830 us/op
-WorkloadWarmup   8: 524288 op, 548070018.00 ns, 1.0454 us/op
+WorkloadWarmup   1: 524288 op, 544087425.00 ns, 1.0378 us/op
+WorkloadWarmup   2: 524288 op, 561115891.00 ns, 1.0702 us/op
+WorkloadWarmup   3: 524288 op, 537597144.00 ns, 1.0254 us/op
+WorkloadWarmup   4: 524288 op, 531927507.00 ns, 1.0146 us/op
+WorkloadWarmup   5: 524288 op, 533198678.00 ns, 1.0170 us/op
+WorkloadWarmup   6: 524288 op, 530532288.00 ns, 1.0119 us/op
 
 // BeforeActualRun
-WorkloadActual   1: 524288 op, 564838536.00 ns, 1.0773 us/op
-WorkloadActual   2: 524288 op, 563250169.00 ns, 1.0743 us/op
-WorkloadActual   3: 524288 op, 558541266.00 ns, 1.0653 us/op
-WorkloadActual   4: 524288 op, 557926424.00 ns, 1.0642 us/op
-WorkloadActual   5: 524288 op, 561557027.00 ns, 1.0711 us/op
-WorkloadActual   6: 524288 op, 571060398.00 ns, 1.0892 us/op
-WorkloadActual   7: 524288 op, 559309577.00 ns, 1.0668 us/op
-WorkloadActual   8: 524288 op, 570858875.00 ns, 1.0888 us/op
-WorkloadActual   9: 524288 op, 559714064.00 ns, 1.0676 us/op
-WorkloadActual  10: 524288 op, 545859956.00 ns, 1.0411 us/op
-WorkloadActual  11: 524288 op, 539492653.00 ns, 1.0290 us/op
-WorkloadActual  12: 524288 op, 544954819.00 ns, 1.0394 us/op
-WorkloadActual  13: 524288 op, 536881946.00 ns, 1.0240 us/op
-WorkloadActual  14: 524288 op, 538479702.00 ns, 1.0271 us/op
-WorkloadActual  15: 524288 op, 539354294.00 ns, 1.0287 us/op
-WorkloadActual  16: 524288 op, 539373376.00 ns, 1.0288 us/op
-WorkloadActual  17: 524288 op, 540243905.00 ns, 1.0304 us/op
-WorkloadActual  18: 524288 op, 541772960.00 ns, 1.0333 us/op
-WorkloadActual  19: 524288 op, 540336208.00 ns, 1.0306 us/op
+WorkloadActual   1: 524288 op, 538457345.00 ns, 1.0270 us/op
+WorkloadActual   2: 524288 op, 562697025.00 ns, 1.0733 us/op
+WorkloadActual   3: 524288 op, 547123735.00 ns, 1.0436 us/op
+WorkloadActual   4: 524288 op, 552677641.00 ns, 1.0541 us/op
+WorkloadActual   5: 524288 op, 545226467.00 ns, 1.0399 us/op
+WorkloadActual   6: 524288 op, 548895474.00 ns, 1.0469 us/op
+WorkloadActual   7: 524288 op, 554006492.00 ns, 1.0567 us/op
+WorkloadActual   8: 524288 op, 541520978.00 ns, 1.0329 us/op
+WorkloadActual   9: 524288 op, 544354810.00 ns, 1.0383 us/op
+WorkloadActual  10: 524288 op, 532970179.00 ns, 1.0166 us/op
+WorkloadActual  11: 524288 op, 533425614.00 ns, 1.0174 us/op
+WorkloadActual  12: 524288 op, 531878697.00 ns, 1.0145 us/op
+WorkloadActual  13: 524288 op, 530409228.00 ns, 1.0117 us/op
+WorkloadActual  14: 524288 op, 531722806.00 ns, 1.0142 us/op
+WorkloadActual  15: 524288 op, 534295228.00 ns, 1.0191 us/op
 
 // AfterActualRun
-WorkloadResult   1: 524288 op, 563153804.00 ns, 1.0741 us/op
-WorkloadResult   2: 524288 op, 561565437.00 ns, 1.0711 us/op
-WorkloadResult   3: 524288 op, 556856534.00 ns, 1.0621 us/op
-WorkloadResult   4: 524288 op, 556241692.00 ns, 1.0609 us/op
-WorkloadResult   5: 524288 op, 559872295.00 ns, 1.0679 us/op
-WorkloadResult   6: 524288 op, 569375666.00 ns, 1.0860 us/op
-WorkloadResult   7: 524288 op, 557624845.00 ns, 1.0636 us/op
-WorkloadResult   8: 524288 op, 569174143.00 ns, 1.0856 us/op
-WorkloadResult   9: 524288 op, 558029332.00 ns, 1.0644 us/op
-WorkloadResult  10: 524288 op, 544175224.00 ns, 1.0379 us/op
-WorkloadResult  11: 524288 op, 537807921.00 ns, 1.0258 us/op
-WorkloadResult  12: 524288 op, 543270087.00 ns, 1.0362 us/op
-WorkloadResult  13: 524288 op, 535197214.00 ns, 1.0208 us/op
-WorkloadResult  14: 524288 op, 536794970.00 ns, 1.0239 us/op
-WorkloadResult  15: 524288 op, 537669562.00 ns, 1.0255 us/op
-WorkloadResult  16: 524288 op, 537688644.00 ns, 1.0256 us/op
-WorkloadResult  17: 524288 op, 538559173.00 ns, 1.0272 us/op
-WorkloadResult  18: 524288 op, 540088228.00 ns, 1.0301 us/op
-WorkloadResult  19: 524288 op, 538651476.00 ns, 1.0274 us/op
+WorkloadResult   1: 524288 op, 536753440.00 ns, 1.0238 us/op
+WorkloadResult   2: 524288 op, 560993120.00 ns, 1.0700 us/op
+WorkloadResult   3: 524288 op, 545419830.00 ns, 1.0403 us/op
+WorkloadResult   4: 524288 op, 550973736.00 ns, 1.0509 us/op
+WorkloadResult   5: 524288 op, 543522562.00 ns, 1.0367 us/op
+WorkloadResult   6: 524288 op, 547191569.00 ns, 1.0437 us/op
+WorkloadResult   7: 524288 op, 552302587.00 ns, 1.0534 us/op
+WorkloadResult   8: 524288 op, 539817073.00 ns, 1.0296 us/op
+WorkloadResult   9: 524288 op, 542650905.00 ns, 1.0350 us/op
+WorkloadResult  10: 524288 op, 531266274.00 ns, 1.0133 us/op
+WorkloadResult  11: 524288 op, 531721709.00 ns, 1.0142 us/op
+WorkloadResult  12: 524288 op, 530174792.00 ns, 1.0112 us/op
+WorkloadResult  13: 524288 op, 528705323.00 ns, 1.0084 us/op
+WorkloadResult  14: 524288 op, 530018901.00 ns, 1.0109 us/op
+WorkloadResult  15: 524288 op, 532591323.00 ns, 1.0158 us/op
 // GC:  9 0 0 226493152 524288
 // Threading:  0 0 524288
 
 // AfterAll
-// Benchmark Process 1876 has exited with code 0.
+// Benchmark Process 1854 has exited with code 0.
 
-Mean = 1.048 us, StdErr = 0.005 us (0.51%), N = 19, StdDev = 0.023 us
-Min = 1.021 us, Q1 = 1.027 us, Median = 1.038 us, Q3 = 1.066 us, Max = 1.086 us
-IQR = 0.040 us, LowerFence = 0.967 us, UpperFence = 1.126 us
-ConfidenceInterval = [1.027 us; 1.069 us] (CI 99.9%), Margin = 0.021 us (1.98% of Mean)
-Skewness = 0.25, Kurtosis = 1.35, MValue = 2
+Mean = 1.030 us, StdErr = 0.005 us (0.47%), N = 15, StdDev = 0.019 us
+Min = 1.008 us, Q1 = 1.014 us, Median = 1.030 us, Q3 = 1.042 us, Max = 1.070 us
+IQR = 0.028 us, LowerFence = 0.971 us, UpperFence = 1.084 us
+ConfidenceInterval = [1.010 us; 1.050 us] (CI 99.9%), Margin = 0.020 us (1.94% of Mean)
+Skewness = 0.49, Kurtosis = 1.99, MValue = 2
 
-// ** Remained 2 (66.7 %) benchmark(s) to run. Estimated finish 2026-02-15 5:47 (0h 0m from now) **
+// ** Remained 2 (66.7 %) benchmark(s) to run. Estimated finish 2026-02-16 5:47 (0h 0m from now) **
 // **************************
 // Benchmark: BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
 // *** Execute ***
 // Launch: 1 / 1
-// Execute: dotnet 229109e4-4bb7-47a2-826d-d98e7b43645d.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeWithIntegrity --job Default --benchmarkId 1 in /app/Benchmarks/bin/Release/net8.0/229109e4-4bb7-47a2-826d-d98e7b43645d/bin/Release/net8.0
+// Execute: dotnet dc873c13-f40c-478c-b885-f641d4254d14.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeWithIntegrity --job Default --benchmarkId 1 in /app/Benchmarks/bin/Release/net8.0/dc873c13-f40c-478c-b885-f641d4254d14/bin/Release/net8.0
 // Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
 // BeforeAnythingElse
 
@@ -164,106 +154,117 @@ Skewness = 0.25, Kurtosis = 1.35, MValue = 2
 // HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
 // Job: DefaultJob
 
-OverheadJitting  1: 1 op, 345314.00 ns, 345.3140 us/op
-WorkloadJitting  1: 1 op, 707944.00 ns, 707.9440 us/op
+OverheadJitting  1: 1 op, 351854.00 ns, 351.8540 us/op
+WorkloadJitting  1: 1 op, 673173.00 ns, 673.1730 us/op
 
-OverheadJitting  2: 16 op, 297689.00 ns, 18.6056 us/op
-WorkloadJitting  2: 16 op, 592778.00 ns, 37.0486 us/op
+OverheadJitting  2: 16 op, 319407.00 ns, 19.9629 us/op
+WorkloadJitting  2: 16 op, 581113.00 ns, 36.3196 us/op
 
-WorkloadPilot    1: 16 op, 259293.00 ns, 16.2058 us/op
-WorkloadPilot    2: 32 op, 378121.00 ns, 11.8163 us/op
-WorkloadPilot    3: 64 op, 756737.00 ns, 11.8240 us/op
-WorkloadPilot    4: 128 op, 1308379.00 ns, 10.2217 us/op
-WorkloadPilot    5: 256 op, 2406217.00 ns, 9.3993 us/op
-WorkloadPilot    6: 512 op, 4643926.00 ns, 9.0702 us/op
-WorkloadPilot    7: 1024 op, 9277918.00 ns, 9.0605 us/op
-WorkloadPilot    8: 2048 op, 18639316.00 ns, 9.1012 us/op
-WorkloadPilot    9: 4096 op, 37608945.00 ns, 9.1819 us/op
-WorkloadPilot   10: 8192 op, 74842500.00 ns, 9.1360 us/op
-WorkloadPilot   11: 16384 op, 181759283.00 ns, 11.0937 us/op
-WorkloadPilot   12: 32768 op, 258541084.00 ns, 7.8900 us/op
-WorkloadPilot   13: 65536 op, 346715710.00 ns, 5.2905 us/op
-WorkloadPilot   14: 131072 op, 680202108.00 ns, 5.1895 us/op
+WorkloadPilot    1: 16 op, 231175.00 ns, 14.4484 us/op
+WorkloadPilot    2: 32 op, 339961.00 ns, 10.6238 us/op
+WorkloadPilot    3: 64 op, 629592.00 ns, 9.8374 us/op
+WorkloadPilot    4: 128 op, 1329519.00 ns, 10.3869 us/op
+WorkloadPilot    5: 256 op, 2556295.00 ns, 9.9855 us/op
+WorkloadPilot    6: 512 op, 5007003.00 ns, 9.7793 us/op
+WorkloadPilot    7: 1024 op, 9704138.00 ns, 9.4767 us/op
+WorkloadPilot    8: 2048 op, 20710588.00 ns, 10.1126 us/op
+WorkloadPilot    9: 4096 op, 39557740.00 ns, 9.6577 us/op
+WorkloadPilot   10: 8192 op, 82907708.00 ns, 10.1206 us/op
+WorkloadPilot   11: 16384 op, 185077782.00 ns, 11.2963 us/op
+WorkloadPilot   12: 32768 op, 256682437.00 ns, 7.8333 us/op
+WorkloadPilot   13: 65536 op, 361710592.00 ns, 5.5193 us/op
+WorkloadPilot   14: 131072 op, 709849343.00 ns, 5.4157 us/op
 
-OverheadWarmup   1: 131072 op, 411736.00 ns, 3.1413 ns/op
-OverheadWarmup   2: 131072 op, 415788.00 ns, 3.1722 ns/op
-OverheadWarmup   3: 131072 op, 408922.00 ns, 3.1198 ns/op
-OverheadWarmup   4: 131072 op, 437432.00 ns, 3.3373 ns/op
-OverheadWarmup   5: 131072 op, 431792.00 ns, 3.2943 ns/op
+OverheadWarmup   1: 131072 op, 468371.00 ns, 3.5734 ns/op
+OverheadWarmup   2: 131072 op, 427933.00 ns, 3.2649 ns/op
+OverheadWarmup   3: 131072 op, 424284.00 ns, 3.2370 ns/op
+OverheadWarmup   4: 131072 op, 408910.00 ns, 3.1197 ns/op
+OverheadWarmup   5: 131072 op, 402331.00 ns, 3.0695 ns/op
+OverheadWarmup   6: 131072 op, 417245.00 ns, 3.1833 ns/op
+OverheadWarmup   7: 131072 op, 409214.00 ns, 3.1221 ns/op
+OverheadWarmup   8: 131072 op, 433438.00 ns, 3.3069 ns/op
+OverheadWarmup   9: 131072 op, 433318.00 ns, 3.3060 ns/op
 
-OverheadActual   1: 131072 op, 402366.00 ns, 3.0698 ns/op
-OverheadActual   2: 131072 op, 408048.00 ns, 3.1132 ns/op
-OverheadActual   3: 131072 op, 402483.00 ns, 3.0707 ns/op
-OverheadActual   4: 131072 op, 402596.00 ns, 3.0716 ns/op
-OverheadActual   5: 131072 op, 402419.00 ns, 3.0702 ns/op
-OverheadActual   6: 131072 op, 411078.00 ns, 3.1363 ns/op
-OverheadActual   7: 131072 op, 401668.00 ns, 3.0645 ns/op
-OverheadActual   8: 131072 op, 409769.00 ns, 3.1263 ns/op
-OverheadActual   9: 131072 op, 417611.00 ns, 3.1861 ns/op
-OverheadActual  10: 131072 op, 409239.00 ns, 3.1222 ns/op
-OverheadActual  11: 131072 op, 442468.00 ns, 3.3758 ns/op
-OverheadActual  12: 131072 op, 435958.00 ns, 3.3261 ns/op
-OverheadActual  13: 131072 op, 432423.00 ns, 3.2991 ns/op
-OverheadActual  14: 131072 op, 443502.00 ns, 3.3837 ns/op
-OverheadActual  15: 131072 op, 404098.00 ns, 3.0830 ns/op
+OverheadActual   1: 131072 op, 409625.00 ns, 3.1252 ns/op
+OverheadActual   2: 131072 op, 408415.00 ns, 3.1160 ns/op
+OverheadActual   3: 131072 op, 409459.00 ns, 3.1239 ns/op
+OverheadActual   4: 131072 op, 409678.00 ns, 3.1256 ns/op
+OverheadActual   5: 131072 op, 440708.00 ns, 3.3623 ns/op
+OverheadActual   6: 131072 op, 427279.00 ns, 3.2599 ns/op
+OverheadActual   7: 131072 op, 442101.00 ns, 3.3730 ns/op
+OverheadActual   8: 131072 op, 571277.00 ns, 4.3585 ns/op
+OverheadActual   9: 131072 op, 580892.00 ns, 4.4319 ns/op
+OverheadActual  10: 131072 op, 528982.00 ns, 4.0358 ns/op
+OverheadActual  11: 131072 op, 452919.00 ns, 3.4555 ns/op
+OverheadActual  12: 131072 op, 429853.00 ns, 3.2795 ns/op
+OverheadActual  13: 131072 op, 432741.00 ns, 3.3016 ns/op
+OverheadActual  14: 131072 op, 409600.00 ns, 3.1250 ns/op
+OverheadActual  15: 131072 op, 409886.00 ns, 3.1272 ns/op
 
-WorkloadWarmup   1: 131072 op, 696029757.00 ns, 5.3103 us/op
-WorkloadWarmup   2: 131072 op, 696518874.00 ns, 5.3140 us/op
-WorkloadWarmup   3: 131072 op, 683836312.00 ns, 5.2173 us/op
-WorkloadWarmup   4: 131072 op, 694827934.00 ns, 5.3011 us/op
-WorkloadWarmup   5: 131072 op, 678370253.00 ns, 5.1756 us/op
-WorkloadWarmup   6: 131072 op, 676512275.00 ns, 5.1614 us/op
+WorkloadWarmup   1: 131072 op, 723696409.00 ns, 5.5214 us/op
+WorkloadWarmup   2: 131072 op, 722098402.00 ns, 5.5092 us/op
+WorkloadWarmup   3: 131072 op, 711735204.00 ns, 5.4301 us/op
+WorkloadWarmup   4: 131072 op, 708744984.00 ns, 5.4073 us/op
+WorkloadWarmup   5: 131072 op, 704694848.00 ns, 5.3764 us/op
+WorkloadWarmup   6: 131072 op, 705832631.00 ns, 5.3851 us/op
+WorkloadWarmup   7: 131072 op, 714680394.00 ns, 5.4526 us/op
+WorkloadWarmup   8: 131072 op, 710998421.00 ns, 5.4245 us/op
+WorkloadWarmup   9: 131072 op, 704032289.00 ns, 5.3713 us/op
+WorkloadWarmup  10: 131072 op, 703083158.00 ns, 5.3641 us/op
+WorkloadWarmup  11: 131072 op, 704911934.00 ns, 5.3781 us/op
+WorkloadWarmup  12: 131072 op, 707074269.00 ns, 5.3945 us/op
+WorkloadWarmup  13: 131072 op, 708872449.00 ns, 5.4083 us/op
+WorkloadWarmup  14: 131072 op, 705621782.00 ns, 5.3835 us/op
 
 // BeforeActualRun
-WorkloadActual   1: 131072 op, 682345818.00 ns, 5.2059 us/op
-WorkloadActual   2: 131072 op, 675410246.00 ns, 5.1530 us/op
-WorkloadActual   3: 131072 op, 680250974.00 ns, 5.1899 us/op
-WorkloadActual   4: 131072 op, 676509951.00 ns, 5.1614 us/op
-WorkloadActual   5: 131072 op, 677315546.00 ns, 5.1675 us/op
-WorkloadActual   6: 131072 op, 721779697.00 ns, 5.5067 us/op
-WorkloadActual   7: 131072 op, 675740263.00 ns, 5.1555 us/op
-WorkloadActual   8: 131072 op, 674087663.00 ns, 5.1429 us/op
-WorkloadActual   9: 131072 op, 675728535.00 ns, 5.1554 us/op
-WorkloadActual  10: 131072 op, 677504020.00 ns, 5.1689 us/op
-WorkloadActual  11: 131072 op, 675262085.00 ns, 5.1518 us/op
-WorkloadActual  12: 131072 op, 681198932.00 ns, 5.1971 us/op
-WorkloadActual  13: 131072 op, 679273211.00 ns, 5.1824 us/op
-WorkloadActual  14: 131072 op, 677517596.00 ns, 5.1690 us/op
-WorkloadActual  15: 131072 op, 676912358.00 ns, 5.1644 us/op
+WorkloadActual   1: 131072 op, 709656361.00 ns, 5.4142 us/op
+WorkloadActual   2: 131072 op, 701501310.00 ns, 5.3520 us/op
+WorkloadActual   3: 131072 op, 702470009.00 ns, 5.3594 us/op
+WorkloadActual   4: 131072 op, 697196524.00 ns, 5.3192 us/op
+WorkloadActual   5: 131072 op, 701686626.00 ns, 5.3534 us/op
+WorkloadActual   6: 131072 op, 701096043.00 ns, 5.3489 us/op
+WorkloadActual   7: 131072 op, 703569571.00 ns, 5.3678 us/op
+WorkloadActual   8: 131072 op, 701240563.00 ns, 5.3500 us/op
+WorkloadActual   9: 131072 op, 698899986.00 ns, 5.3322 us/op
+WorkloadActual  10: 131072 op, 700856811.00 ns, 5.3471 us/op
+WorkloadActual  11: 131072 op, 700772402.00 ns, 5.3465 us/op
+WorkloadActual  12: 131072 op, 703005880.00 ns, 5.3635 us/op
+WorkloadActual  13: 131072 op, 702354582.00 ns, 5.3585 us/op
+WorkloadActual  14: 131072 op, 701731898.00 ns, 5.3538 us/op
+WorkloadActual  15: 131072 op, 720200355.00 ns, 5.4947 us/op
 
 // AfterActualRun
-WorkloadResult   1: 131072 op, 681936579.00 ns, 5.2028 us/op
-WorkloadResult   2: 131072 op, 675001007.00 ns, 5.1498 us/op
-WorkloadResult   3: 131072 op, 679841735.00 ns, 5.1868 us/op
-WorkloadResult   4: 131072 op, 676100712.00 ns, 5.1582 us/op
-WorkloadResult   5: 131072 op, 676906307.00 ns, 5.1644 us/op
-WorkloadResult   6: 131072 op, 675331024.00 ns, 5.1524 us/op
-WorkloadResult   7: 131072 op, 673678424.00 ns, 5.1398 us/op
-WorkloadResult   8: 131072 op, 675319296.00 ns, 5.1523 us/op
-WorkloadResult   9: 131072 op, 677094781.00 ns, 5.1658 us/op
-WorkloadResult  10: 131072 op, 674852846.00 ns, 5.1487 us/op
-WorkloadResult  11: 131072 op, 680789693.00 ns, 5.1940 us/op
-WorkloadResult  12: 131072 op, 678863972.00 ns, 5.1793 us/op
-WorkloadResult  13: 131072 op, 677108357.00 ns, 5.1659 us/op
-WorkloadResult  14: 131072 op, 676503119.00 ns, 5.1613 us/op
-// GC:  3 0 0 75498208 131072
+WorkloadResult   1: 131072 op, 701071457.00 ns, 5.3488 us/op
+WorkloadResult   2: 131072 op, 702040156.00 ns, 5.3561 us/op
+WorkloadResult   3: 131072 op, 696766671.00 ns, 5.3159 us/op
+WorkloadResult   4: 131072 op, 701256773.00 ns, 5.3502 us/op
+WorkloadResult   5: 131072 op, 700666190.00 ns, 5.3457 us/op
+WorkloadResult   6: 131072 op, 703139718.00 ns, 5.3645 us/op
+WorkloadResult   7: 131072 op, 700810710.00 ns, 5.3468 us/op
+WorkloadResult   8: 131072 op, 698470133.00 ns, 5.3289 us/op
+WorkloadResult   9: 131072 op, 700426958.00 ns, 5.3438 us/op
+WorkloadResult  10: 131072 op, 700342549.00 ns, 5.3432 us/op
+WorkloadResult  11: 131072 op, 702576027.00 ns, 5.3602 us/op
+WorkloadResult  12: 131072 op, 701924729.00 ns, 5.3553 us/op
+WorkloadResult  13: 131072 op, 701302045.00 ns, 5.3505 us/op
+// GC:  2 0 0 68158176 131072
 // Threading:  0 0 131072
 
 // AfterAll
-// Benchmark Process 1892 has exited with code 0.
+// Benchmark Process 1870 has exited with code 0.
 
-Mean = 5.166 us, StdErr = 0.005 us (0.10%), N = 14, StdDev = 0.019 us
-Min = 5.140 us, Q1 = 5.152 us, Median = 5.163 us, Q3 = 5.176 us, Max = 5.203 us
-IQR = 0.024 us, LowerFence = 5.117 us, UpperFence = 5.211 us
-ConfidenceInterval = [5.145 us; 5.187 us] (CI 99.9%), Margin = 0.021 us (0.40% of Mean)
-Skewness = 0.59, Kurtosis = 2.07, MValue = 2
+Mean = 5.347 us, StdErr = 0.004 us (0.07%), N = 13, StdDev = 0.013 us
+Min = 5.316 us, Q1 = 5.344 us, Median = 5.349 us, Q3 = 5.355 us, Max = 5.365 us
+IQR = 0.011 us, LowerFence = 5.327 us, UpperFence = 5.372 us
+ConfidenceInterval = [5.332 us; 5.362 us] (CI 99.9%), Margin = 0.015 us (0.29% of Mean)
+Skewness = -0.96, Kurtosis = 3.3, MValue = 2
 
-// ** Remained 1 (33.3 %) benchmark(s) to run. Estimated finish 2026-02-15 5:47 (0h 0m from now) **
+// ** Remained 1 (33.3 %) benchmark(s) to run. Estimated finish 2026-02-16 5:47 (0h 0m from now) **
 // **************************
 // Benchmark: BinaryPacketBenchmark.DeserializeWithIntegrity: DefaultJob
 // *** Execute ***
 // Launch: 1 / 1
-// Execute: dotnet 229109e4-4bb7-47a2-826d-d98e7b43645d.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.DeserializeWithIntegrity --job Default --benchmarkId 2 in /app/Benchmarks/bin/Release/net8.0/229109e4-4bb7-47a2-826d-d98e7b43645d/bin/Release/net8.0
+// Execute: dotnet dc873c13-f40c-478c-b885-f641d4254d14.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.DeserializeWithIntegrity --job Default --benchmarkId 2 in /app/Benchmarks/bin/Release/net8.0/dc873c13-f40c-478c-b885-f641d4254d14/bin/Release/net8.0
 // Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
 // BeforeAnythingElse
 
@@ -274,94 +275,92 @@ Skewness = 0.59, Kurtosis = 2.07, MValue = 2
 // HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
 // Job: DefaultJob
 
-OverheadJitting  1: 1 op, 409722.00 ns, 409.7220 us/op
-WorkloadJitting  1: 1 op, 41259903.00 ns, 41.2599 ms/op
+OverheadJitting  1: 1 op, 400202.00 ns, 400.2020 us/op
+WorkloadJitting  1: 1 op, 38583767.00 ns, 38.5838 ms/op
 
-WorkloadPilot    1: 2 op, 130240.00 ns, 65.1200 us/op
-WorkloadPilot    2: 3 op, 164879.00 ns, 54.9597 us/op
-WorkloadPilot    3: 4 op, 86839.00 ns, 21.7097 us/op
-WorkloadPilot    4: 5 op, 150647.00 ns, 30.1294 us/op
-WorkloadPilot    5: 6 op, 119400.00 ns, 19.9000 us/op
-WorkloadPilot    6: 7 op, 128897.00 ns, 18.4139 us/op
-WorkloadPilot    7: 8 op, 209133.00 ns, 26.1416 us/op
-WorkloadPilot    8: 9 op, 151118.00 ns, 16.7909 us/op
-WorkloadPilot    9: 10 op, 210709.00 ns, 21.0709 us/op
-WorkloadPilot   10: 11 op, 179180.00 ns, 16.2891 us/op
-WorkloadPilot   11: 12 op, 254512.00 ns, 21.2093 us/op
-WorkloadPilot   12: 13 op, 258219.00 ns, 19.8630 us/op
-WorkloadPilot   13: 14 op, 219862.00 ns, 15.7044 us/op
-WorkloadPilot   14: 15 op, 287516.00 ns, 19.1677 us/op
-WorkloadPilot   15: 16 op, 244430.00 ns, 15.2769 us/op
-WorkloadPilot   16: 32 op, 428386.00 ns, 13.3871 us/op
-WorkloadPilot   17: 64 op, 853428.00 ns, 13.3348 us/op
-WorkloadPilot   18: 128 op, 1750060.00 ns, 13.6723 us/op
-WorkloadPilot   19: 256 op, 3295969.00 ns, 12.8749 us/op
-WorkloadPilot   20: 512 op, 6576067.00 ns, 12.8439 us/op
-WorkloadPilot   21: 1024 op, 13068119.00 ns, 12.7618 us/op
-WorkloadPilot   22: 2048 op, 27035473.00 ns, 13.2009 us/op
-WorkloadPilot   23: 4096 op, 60870453.00 ns, 14.8610 us/op
-WorkloadPilot   24: 8192 op, 155070943.00 ns, 18.9296 us/op
-WorkloadPilot   25: 16384 op, 244809867.00 ns, 14.9420 us/op
-WorkloadPilot   26: 32768 op, 256042949.00 ns, 7.8138 us/op
-WorkloadPilot   27: 65536 op, 449227418.00 ns, 6.8547 us/op
-WorkloadPilot   28: 131072 op, 909557740.00 ns, 6.9394 us/op
+WorkloadPilot    1: 2 op, 124508.00 ns, 62.2540 us/op
+WorkloadPilot    2: 3 op, 77852.00 ns, 25.9507 us/op
+WorkloadPilot    3: 4 op, 80364.00 ns, 20.0910 us/op
+WorkloadPilot    4: 5 op, 103272.00 ns, 20.6544 us/op
+WorkloadPilot    5: 6 op, 164810.00 ns, 27.4683 us/op
+WorkloadPilot    6: 7 op, 124153.00 ns, 17.7361 us/op
+WorkloadPilot    7: 8 op, 135676.00 ns, 16.9595 us/op
+WorkloadPilot    8: 9 op, 145667.00 ns, 16.1852 us/op
+WorkloadPilot    9: 10 op, 156930.00 ns, 15.6930 us/op
+WorkloadPilot   10: 11 op, 169537.00 ns, 15.4125 us/op
+WorkloadPilot   11: 12 op, 219087.00 ns, 18.2572 us/op
+WorkloadPilot   12: 13 op, 188106.00 ns, 14.4697 us/op
+WorkloadPilot   13: 14 op, 244121.00 ns, 17.4372 us/op
+WorkloadPilot   14: 15 op, 220128.00 ns, 14.6752 us/op
+WorkloadPilot   15: 16 op, 228950.00 ns, 14.3094 us/op
+WorkloadPilot   16: 32 op, 459702.00 ns, 14.3657 us/op
+WorkloadPilot   17: 64 op, 827173.00 ns, 12.9246 us/op
+WorkloadPilot   18: 128 op, 1721710.00 ns, 13.4509 us/op
+WorkloadPilot   19: 256 op, 3387777.00 ns, 13.2335 us/op
+WorkloadPilot   20: 512 op, 6296985.00 ns, 12.2988 us/op
+WorkloadPilot   21: 1024 op, 12717717.00 ns, 12.4196 us/op
+WorkloadPilot   22: 2048 op, 25909554.00 ns, 12.6511 us/op
+WorkloadPilot   23: 4096 op, 54563217.00 ns, 13.3211 us/op
+WorkloadPilot   24: 8192 op, 146509664.00 ns, 17.8845 us/op
+WorkloadPilot   25: 16384 op, 249280099.00 ns, 15.2148 us/op
+WorkloadPilot   26: 32768 op, 261882323.00 ns, 7.9920 us/op
+WorkloadPilot   27: 65536 op, 465937092.00 ns, 7.1096 us/op
+WorkloadPilot   28: 131072 op, 921905312.00 ns, 7.0336 us/op
 
-WorkloadWarmup   1: 131072 op, 892539154.00 ns, 6.8095 us/op
-WorkloadWarmup   2: 131072 op, 893077892.00 ns, 6.8136 us/op
-WorkloadWarmup   3: 131072 op, 894775644.00 ns, 6.8266 us/op
-WorkloadWarmup   4: 131072 op, 895782970.00 ns, 6.8343 us/op
-WorkloadWarmup   5: 131072 op, 897111891.00 ns, 6.8444 us/op
-WorkloadWarmup   6: 131072 op, 898545448.00 ns, 6.8554 us/op
-WorkloadWarmup   7: 131072 op, 902381412.00 ns, 6.8846 us/op
-WorkloadWarmup   8: 131072 op, 895616737.00 ns, 6.8330 us/op
-WorkloadWarmup   9: 131072 op, 896058165.00 ns, 6.8364 us/op
-WorkloadWarmup  10: 131072 op, 897160219.00 ns, 6.8448 us/op
-WorkloadWarmup  11: 131072 op, 893601697.00 ns, 6.8176 us/op
+WorkloadWarmup   1: 131072 op, 928632475.00 ns, 7.0849 us/op
+WorkloadWarmup   2: 131072 op, 923798310.00 ns, 7.0480 us/op
+WorkloadWarmup   3: 131072 op, 925164855.00 ns, 7.0584 us/op
+WorkloadWarmup   4: 131072 op, 935851625.00 ns, 7.1400 us/op
+WorkloadWarmup   5: 131072 op, 924659542.00 ns, 7.0546 us/op
+WorkloadWarmup   6: 131072 op, 921484591.00 ns, 7.0304 us/op
+WorkloadWarmup   7: 131072 op, 916257678.00 ns, 6.9905 us/op
+WorkloadWarmup   8: 131072 op, 934711430.00 ns, 7.1313 us/op
+WorkloadWarmup   9: 131072 op, 915212694.00 ns, 6.9825 us/op
 
 // BeforeActualRun
-WorkloadActual   1: 131072 op, 898213064.00 ns, 6.8528 us/op
-WorkloadActual   2: 131072 op, 893407927.00 ns, 6.8162 us/op
-WorkloadActual   3: 131072 op, 893131713.00 ns, 6.8141 us/op
-WorkloadActual   4: 131072 op, 894806434.00 ns, 6.8268 us/op
-WorkloadActual   5: 131072 op, 895458705.00 ns, 6.8318 us/op
-WorkloadActual   6: 131072 op, 915391676.00 ns, 6.9839 us/op
-WorkloadActual   7: 131072 op, 911957609.00 ns, 6.9577 us/op
-WorkloadActual   8: 131072 op, 895805243.00 ns, 6.8345 us/op
-WorkloadActual   9: 131072 op, 900190884.00 ns, 6.8679 us/op
-WorkloadActual  10: 131072 op, 900878162.00 ns, 6.8732 us/op
-WorkloadActual  11: 131072 op, 902675013.00 ns, 6.8869 us/op
-WorkloadActual  12: 131072 op, 897887056.00 ns, 6.8503 us/op
-WorkloadActual  13: 131072 op, 893503555.00 ns, 6.8169 us/op
-WorkloadActual  14: 131072 op, 892790520.00 ns, 6.8115 us/op
-WorkloadActual  15: 131072 op, 890681698.00 ns, 6.7954 us/op
+WorkloadActual   1: 131072 op, 920639167.00 ns, 7.0239 us/op
+WorkloadActual   2: 131072 op, 918985584.00 ns, 7.0113 us/op
+WorkloadActual   3: 131072 op, 913978477.00 ns, 6.9731 us/op
+WorkloadActual   4: 131072 op, 915410280.00 ns, 6.9840 us/op
+WorkloadActual   5: 131072 op, 907680070.00 ns, 6.9250 us/op
+WorkloadActual   6: 131072 op, 918294571.00 ns, 7.0060 us/op
+WorkloadActual   7: 131072 op, 981351954.00 ns, 7.4871 us/op
+WorkloadActual   8: 131072 op, 930720100.00 ns, 7.1008 us/op
+WorkloadActual   9: 131072 op, 929738271.00 ns, 7.0933 us/op
+WorkloadActual  10: 131072 op, 925130269.00 ns, 7.0582 us/op
+WorkloadActual  11: 131072 op, 918215169.00 ns, 7.0054 us/op
+WorkloadActual  12: 131072 op, 915954225.00 ns, 6.9882 us/op
+WorkloadActual  13: 131072 op, 911940081.00 ns, 6.9576 us/op
+WorkloadActual  14: 131072 op, 908755657.00 ns, 6.9333 us/op
+WorkloadActual  15: 131072 op, 975685099.00 ns, 7.4439 us/op
 
 // AfterActualRun
-WorkloadResult   1: 131072 op, 898213064.00 ns, 6.8528 us/op
-WorkloadResult   2: 131072 op, 893407927.00 ns, 6.8162 us/op
-WorkloadResult   3: 131072 op, 893131713.00 ns, 6.8141 us/op
-WorkloadResult   4: 131072 op, 894806434.00 ns, 6.8268 us/op
-WorkloadResult   5: 131072 op, 895458705.00 ns, 6.8318 us/op
-WorkloadResult   6: 131072 op, 895805243.00 ns, 6.8345 us/op
-WorkloadResult   7: 131072 op, 900190884.00 ns, 6.8679 us/op
-WorkloadResult   8: 131072 op, 900878162.00 ns, 6.8732 us/op
-WorkloadResult   9: 131072 op, 902675013.00 ns, 6.8869 us/op
-WorkloadResult  10: 131072 op, 897887056.00 ns, 6.8503 us/op
-WorkloadResult  11: 131072 op, 893503555.00 ns, 6.8169 us/op
-WorkloadResult  12: 131072 op, 892790520.00 ns, 6.8115 us/op
-WorkloadResult  13: 131072 op, 890681698.00 ns, 6.7954 us/op
-// GC:  4 0 0 102761184 131072
+WorkloadResult   1: 131072 op, 920639167.00 ns, 7.0239 us/op
+WorkloadResult   2: 131072 op, 918985584.00 ns, 7.0113 us/op
+WorkloadResult   3: 131072 op, 913978477.00 ns, 6.9731 us/op
+WorkloadResult   4: 131072 op, 915410280.00 ns, 6.9840 us/op
+WorkloadResult   5: 131072 op, 907680070.00 ns, 6.9250 us/op
+WorkloadResult   6: 131072 op, 918294571.00 ns, 7.0060 us/op
+WorkloadResult   7: 131072 op, 930720100.00 ns, 7.1008 us/op
+WorkloadResult   8: 131072 op, 929738271.00 ns, 7.0933 us/op
+WorkloadResult   9: 131072 op, 925130269.00 ns, 7.0582 us/op
+WorkloadResult  10: 131072 op, 918215169.00 ns, 7.0054 us/op
+WorkloadResult  11: 131072 op, 915954225.00 ns, 6.9882 us/op
+WorkloadResult  12: 131072 op, 911940081.00 ns, 6.9576 us/op
+WorkloadResult  13: 131072 op, 908755657.00 ns, 6.9333 us/op
+// GC:  4 0 0 95421152 131072
 // Threading:  0 0 131072
 
 // AfterAll
-// Benchmark Process 1907 has exited with code 0.
+// Benchmark Process 1883 has exited with code 0.
 
-Mean = 6.837 us, StdErr = 0.008 us (0.11%), N = 13, StdDev = 0.027 us
-Min = 6.795 us, Q1 = 6.816 us, Median = 6.832 us, Q3 = 6.853 us, Max = 6.887 us
-IQR = 0.037 us, LowerFence = 6.761 us, UpperFence = 6.908 us
-ConfidenceInterval = [6.804 us; 6.870 us] (CI 99.9%), Margin = 0.033 us (0.48% of Mean)
-Skewness = 0.35, Kurtosis = 1.76, MValue = 2
+Mean = 7.005 us, StdErr = 0.015 us (0.22%), N = 13, StdDev = 0.055 us
+Min = 6.925 us, Q1 = 6.973 us, Median = 7.005 us, Q3 = 7.024 us, Max = 7.101 us
+IQR = 0.051 us, LowerFence = 6.897 us, UpperFence = 7.100 us
+ConfidenceInterval = [6.939 us; 7.070 us] (CI 99.9%), Margin = 0.065 us (0.93% of Mean)
+Skewness = 0.35, Kurtosis = 1.98, MValue = 2
 
-// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-02-15 5:47 (0h 0m from now) **
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-02-16 5:48 (0h 0m from now) **
 // ***** BenchmarkRunner: Finish  *****
 
 // * Export *
@@ -372,36 +371,36 @@ Skewness = 0.35, Kurtosis = 1.76, MValue = 2
 // * Detailed results *
 BinaryPacketBenchmark.SerializeToWriter: DefaultJob
 Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
-Mean = 1.048 us, StdErr = 0.005 us (0.51%), N = 19, StdDev = 0.023 us
-Min = 1.021 us, Q1 = 1.027 us, Median = 1.038 us, Q3 = 1.066 us, Max = 1.086 us
-IQR = 0.040 us, LowerFence = 0.967 us, UpperFence = 1.126 us
-ConfidenceInterval = [1.027 us; 1.069 us] (CI 99.9%), Margin = 0.021 us (1.98% of Mean)
-Skewness = 0.25, Kurtosis = 1.35, MValue = 2
+Mean = 1.030 us, StdErr = 0.005 us (0.47%), N = 15, StdDev = 0.019 us
+Min = 1.008 us, Q1 = 1.014 us, Median = 1.030 us, Q3 = 1.042 us, Max = 1.070 us
+IQR = 0.028 us, LowerFence = 0.971 us, UpperFence = 1.084 us
+ConfidenceInterval = [1.010 us; 1.050 us] (CI 99.9%), Margin = 0.020 us (1.94% of Mean)
+Skewness = 0.49, Kurtosis = 1.99, MValue = 2
 -------------------- Histogram --------------------
-[1.018 us ; 1.056 us) | @@@@@@@@@@
-[1.056 us ; 1.097 us) | @@@@@@@@@
+[1.006 us ; 1.034 us) | @@@@@@@@
+[1.034 us ; 1.080 us) | @@@@@@@
 ---------------------------------------------------
 
 BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
 Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
-Mean = 5.166 us, StdErr = 0.005 us (0.10%), N = 14, StdDev = 0.019 us
-Min = 5.140 us, Q1 = 5.152 us, Median = 5.163 us, Q3 = 5.176 us, Max = 5.203 us
-IQR = 0.024 us, LowerFence = 5.117 us, UpperFence = 5.211 us
-ConfidenceInterval = [5.145 us; 5.187 us] (CI 99.9%), Margin = 0.021 us (0.40% of Mean)
-Skewness = 0.59, Kurtosis = 2.07, MValue = 2
+Mean = 5.347 us, StdErr = 0.004 us (0.07%), N = 13, StdDev = 0.013 us
+Min = 5.316 us, Q1 = 5.344 us, Median = 5.349 us, Q3 = 5.355 us, Max = 5.365 us
+IQR = 0.011 us, LowerFence = 5.327 us, UpperFence = 5.372 us
+ConfidenceInterval = [5.332 us; 5.362 us] (CI 99.9%), Margin = 0.015 us (0.29% of Mean)
+Skewness = -0.96, Kurtosis = 3.3, MValue = 2
 -------------------- Histogram --------------------
-[5.130 us ; 5.213 us) | @@@@@@@@@@@@@@
+[5.309 us ; 5.372 us) | @@@@@@@@@@@@@
 ---------------------------------------------------
 
 BinaryPacketBenchmark.DeserializeWithIntegrity: DefaultJob
 Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
-Mean = 6.837 us, StdErr = 0.008 us (0.11%), N = 13, StdDev = 0.027 us
-Min = 6.795 us, Q1 = 6.816 us, Median = 6.832 us, Q3 = 6.853 us, Max = 6.887 us
-IQR = 0.037 us, LowerFence = 6.761 us, UpperFence = 6.908 us
-ConfidenceInterval = [6.804 us; 6.870 us] (CI 99.9%), Margin = 0.033 us (0.48% of Mean)
-Skewness = 0.35, Kurtosis = 1.76, MValue = 2
+Mean = 7.005 us, StdErr = 0.015 us (0.22%), N = 13, StdDev = 0.055 us
+Min = 6.925 us, Q1 = 6.973 us, Median = 7.005 us, Q3 = 7.024 us, Max = 7.101 us
+IQR = 0.051 us, LowerFence = 6.897 us, UpperFence = 7.100 us
+ConfidenceInterval = [6.939 us; 7.070 us] (CI 99.9%), Margin = 0.065 us (0.93% of Mean)
+Skewness = 0.35, Kurtosis = 1.98, MValue = 2
 -------------------- Histogram --------------------
-[6.780 us ; 6.902 us) | @@@@@@@@@@@@@
+[6.895 us ; 7.131 us) | @@@@@@@@@@@@@
 ---------------------------------------------------
 
 // * Summary *
@@ -415,14 +414,14 @@ Intel Xeon Processor 2.30GHz, 1 CPU, 4 logical and 4 physical cores
 
 | Method                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
 |------------------------- |---------:|----------:|----------:|-------:|----------:|
-| SerializeToWriter        | 1.048 us | 0.0208 us | 0.0231 us | 0.0172 |     432 B |
-| SerializeWithIntegrity   | 5.166 us | 0.0209 us | 0.0185 us | 0.0229 |     576 B |
-| DeserializeWithIntegrity | 6.837 us | 0.0329 us | 0.0275 us | 0.0305 |     784 B |
+| SerializeToWriter        | 1.030 us | 0.0200 us | 0.0187 us | 0.0172 |     432 B |
+| SerializeWithIntegrity   | 5.347 us | 0.0154 us | 0.0128 us | 0.0153 |     520 B |
+| DeserializeWithIntegrity | 7.005 us | 0.0654 us | 0.0546 us | 0.0305 |     728 B |
 
 // * Hints *
 Outliers
-  BinaryPacketBenchmark.SerializeWithIntegrity: Default   -> 1 outlier  was  removed (5.51 us)
-  BinaryPacketBenchmark.DeserializeWithIntegrity: Default -> 2 outliers were removed (6.96 us, 6.98 us)
+  BinaryPacketBenchmark.SerializeWithIntegrity: Default   -> 2 outliers were removed, 3 outliers were detected (5.32 us, 5.41 us, 5.49 us)
+  BinaryPacketBenchmark.DeserializeWithIntegrity: Default -> 2 outliers were removed (7.44 us, 7.49 us)
 
 // * Legends *
   Mean      : Arithmetic mean of all measurements
@@ -436,8 +435,8 @@ Outliers
 
 
 // ***** BenchmarkRunner: End *****
-Run time: 00:01:01 (61.7 sec), executed benchmarks: 3
+Run time: 00:01:03 (63.36 sec), executed benchmarks: 3
 
-Global total time: 00:01:12 (72.25 sec), executed benchmarks: 3
+Global total time: 00:01:14 (74.41 sec), executed benchmarks: 3
 // * Artifacts cleanup *
 Artifacts cleanup is finished

--- a/benchmark_result.txt
+++ b/benchmark_result.txt
@@ -1,0 +1,3 @@
+/app/MulticastTransportFramework/BinaryPacket.cs(295,29): error CS0136: A local or parameter named 'written' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter [/app/MulticastTransportFramework/MulticastTransportFramework.csproj]
+/app/MulticastTransportFramework/BinaryPacket.cs(396,58): warning CS8602: Dereference of a possibly null reference. [/app/MulticastTransportFramework/MulticastTransportFramework.csproj]
+/app/MulticastTransportFramework/BinaryPacket.cs(402,56): warning CS8602: Dereference of a possibly null reference. [/app/MulticastTransportFramework/MulticastTransportFramework.csproj]

--- a/benchmark_result_v2.txt
+++ b/benchmark_result_v2.txt
@@ -1,0 +1,453 @@
+/app/Benchmarks/BinaryPacketBenchmark.cs(14,39): warning CS8618: Non-nullable field '_jsonOptions' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(15,56): warning CS8618: Non-nullable field '_writer' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(16,24): warning CS8618: Non-nullable field '_integrityKey' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/BinaryPacketBenchmark.cs(17,24): warning CS8618: Non-nullable field '_serializedWithIntegrity' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/SerializationBenchmark.cs(14,24): warning CS8618: Non-nullable field '_jsonNewtonsoft' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/SerializationBenchmark.cs(15,24): warning CS8618: Non-nullable field '_jsonSystemText' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/SerializationBenchmark.cs(16,40): warning CS8618: Non-nullable field '_newtonsoftSettings' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/SerializationBenchmark.cs(17,39): warning CS8618: Non-nullable field '_systemTextOptions' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+/app/Benchmarks/SerializationBenchmark.cs(18,42): warning CS8618: Non-nullable field '_knownTypes' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable. [/app/Benchmarks/Benchmarks.csproj]
+// Validating benchmarks:
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 3 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet  restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/7b35e4a4-627d-434a-a2d8-02bd28e71507
+// command took 3.26 sec and exited with 0
+// start dotnet  build -c Release --no-restore /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 /p:Deterministic=true /p:Optimize=true in /app/Benchmarks/bin/Release/net8.0/7b35e4a4-627d-434a-a2d8-02bd28e71507
+// command took 6.72 sec and exited with 0
+// ***** Done, took 00:00:10 (10.11 sec)   *****
+// Found 3 benchmarks:
+//   BinaryPacketBenchmark.SerializeToWriter: DefaultJob
+//   BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
+//   BinaryPacketBenchmark.DeserializeWithIntegrity: DefaultJob
+
+// **************************
+// Benchmark: BinaryPacketBenchmark.SerializeToWriter: DefaultJob
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet 7b35e4a4-627d-434a-a2d8-02bd28e71507.dll --anonymousPipes 117 118 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeToWriter --job Default --benchmarkId 0 in /app/Benchmarks/bin/Release/net8.0/7b35e4a4-627d-434a-a2d8-02bd28e71507/bin/Release/net8.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.13.12
+// Runtime=.NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 350571.00 ns, 350.5710 us/op
+WorkloadJitting  1: 1 op, 835794.00 ns, 835.7940 us/op
+
+OverheadJitting  2: 16 op, 298790.00 ns, 18.6744 us/op
+WorkloadJitting  2: 16 op, 489743.00 ns, 30.6089 us/op
+
+WorkloadPilot    1: 16 op, 101550.00 ns, 6.3469 us/op
+WorkloadPilot    2: 32 op, 149047.00 ns, 4.6577 us/op
+WorkloadPilot    3: 64 op, 296999.00 ns, 4.6406 us/op
+WorkloadPilot    4: 128 op, 532315.00 ns, 4.1587 us/op
+WorkloadPilot    5: 256 op, 911674.00 ns, 3.5612 us/op
+WorkloadPilot    6: 512 op, 1813468.00 ns, 3.5419 us/op
+WorkloadPilot    7: 1024 op, 3298211.00 ns, 3.2209 us/op
+WorkloadPilot    8: 2048 op, 6566148.00 ns, 3.2061 us/op
+WorkloadPilot    9: 4096 op, 13342979.00 ns, 3.2576 us/op
+WorkloadPilot   10: 8192 op, 26901629.00 ns, 3.2839 us/op
+WorkloadPilot   11: 16384 op, 53616495.00 ns, 3.2725 us/op
+WorkloadPilot   12: 32768 op, 149527744.00 ns, 4.5632 us/op
+WorkloadPilot   13: 65536 op, 255344680.00 ns, 3.8963 us/op
+WorkloadPilot   14: 131072 op, 135563829.00 ns, 1.0343 us/op
+WorkloadPilot   15: 262144 op, 269197165.00 ns, 1.0269 us/op
+WorkloadPilot   16: 524288 op, 539048282.00 ns, 1.0282 us/op
+
+OverheadWarmup   1: 524288 op, 1714241.00 ns, 3.2697 ns/op
+OverheadWarmup   2: 524288 op, 1754368.00 ns, 3.3462 ns/op
+OverheadWarmup   3: 524288 op, 1705519.00 ns, 3.2530 ns/op
+OverheadWarmup   4: 524288 op, 1671900.00 ns, 3.1889 ns/op
+OverheadWarmup   5: 524288 op, 1726422.00 ns, 3.2929 ns/op
+OverheadWarmup   6: 524288 op, 1707760.00 ns, 3.2573 ns/op
+
+OverheadActual   1: 524288 op, 1705583.00 ns, 3.2531 ns/op
+OverheadActual   2: 524288 op, 1795227.00 ns, 3.4241 ns/op
+OverheadActual   3: 524288 op, 1760719.00 ns, 3.3583 ns/op
+OverheadActual   4: 524288 op, 1721994.00 ns, 3.2844 ns/op
+OverheadActual   5: 524288 op, 1703508.00 ns, 3.2492 ns/op
+OverheadActual   6: 524288 op, 1710217.00 ns, 3.2620 ns/op
+OverheadActual   7: 524288 op, 1673078.00 ns, 3.1911 ns/op
+OverheadActual   8: 524288 op, 1738891.00 ns, 3.3167 ns/op
+OverheadActual   9: 524288 op, 1730080.00 ns, 3.2999 ns/op
+OverheadActual  10: 524288 op, 1707764.00 ns, 3.2573 ns/op
+OverheadActual  11: 524288 op, 1702378.00 ns, 3.2470 ns/op
+OverheadActual  12: 524288 op, 1711075.00 ns, 3.2636 ns/op
+OverheadActual  13: 524288 op, 1723780.00 ns, 3.2878 ns/op
+OverheadActual  14: 524288 op, 1739310.00 ns, 3.3175 ns/op
+OverheadActual  15: 524288 op, 1755125.00 ns, 3.3476 ns/op
+
+WorkloadWarmup   1: 524288 op, 565766899.00 ns, 1.0791 us/op
+WorkloadWarmup   2: 524288 op, 554082385.00 ns, 1.0568 us/op
+WorkloadWarmup   3: 524288 op, 544206557.00 ns, 1.0380 us/op
+WorkloadWarmup   4: 524288 op, 538546057.00 ns, 1.0272 us/op
+WorkloadWarmup   5: 524288 op, 537150432.00 ns, 1.0245 us/op
+WorkloadWarmup   6: 524288 op, 536504840.00 ns, 1.0233 us/op
+WorkloadWarmup   7: 524288 op, 538306251.00 ns, 1.0267 us/op
+WorkloadWarmup   8: 524288 op, 538043936.00 ns, 1.0262 us/op
+WorkloadWarmup   9: 524288 op, 536060163.00 ns, 1.0225 us/op
+WorkloadWarmup  10: 524288 op, 535925297.00 ns, 1.0222 us/op
+WorkloadWarmup  11: 524288 op, 535689388.00 ns, 1.0217 us/op
+WorkloadWarmup  12: 524288 op, 537900538.00 ns, 1.0260 us/op
+WorkloadWarmup  13: 524288 op, 536837337.00 ns, 1.0239 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 524288 op, 539139873.00 ns, 1.0283 us/op
+WorkloadActual   2: 524288 op, 534815207.00 ns, 1.0201 us/op
+WorkloadActual   3: 524288 op, 534551622.00 ns, 1.0196 us/op
+WorkloadActual   4: 524288 op, 534242237.00 ns, 1.0190 us/op
+WorkloadActual   5: 524288 op, 534332155.00 ns, 1.0192 us/op
+WorkloadActual   6: 524288 op, 533847067.00 ns, 1.0182 us/op
+WorkloadActual   7: 524288 op, 536488270.00 ns, 1.0233 us/op
+WorkloadActual   8: 524288 op, 536604607.00 ns, 1.0235 us/op
+WorkloadActual   9: 524288 op, 537021585.00 ns, 1.0243 us/op
+WorkloadActual  10: 524288 op, 540175124.00 ns, 1.0303 us/op
+WorkloadActual  11: 524288 op, 540840205.00 ns, 1.0316 us/op
+WorkloadActual  12: 524288 op, 541116406.00 ns, 1.0321 us/op
+WorkloadActual  13: 524288 op, 542216755.00 ns, 1.0342 us/op
+WorkloadActual  14: 524288 op, 542634827.00 ns, 1.0350 us/op
+WorkloadActual  15: 524288 op, 541803571.00 ns, 1.0334 us/op
+
+// AfterActualRun
+WorkloadResult   1: 524288 op, 537417879.00 ns, 1.0250 us/op
+WorkloadResult   2: 524288 op, 533093213.00 ns, 1.0168 us/op
+WorkloadResult   3: 524288 op, 532829628.00 ns, 1.0163 us/op
+WorkloadResult   4: 524288 op, 532520243.00 ns, 1.0157 us/op
+WorkloadResult   5: 524288 op, 532610161.00 ns, 1.0159 us/op
+WorkloadResult   6: 524288 op, 532125073.00 ns, 1.0149 us/op
+WorkloadResult   7: 524288 op, 534766276.00 ns, 1.0200 us/op
+WorkloadResult   8: 524288 op, 534882613.00 ns, 1.0202 us/op
+WorkloadResult   9: 524288 op, 535299591.00 ns, 1.0210 us/op
+WorkloadResult  10: 524288 op, 538453130.00 ns, 1.0270 us/op
+WorkloadResult  11: 524288 op, 539118211.00 ns, 1.0283 us/op
+WorkloadResult  12: 524288 op, 539394412.00 ns, 1.0288 us/op
+WorkloadResult  13: 524288 op, 540494761.00 ns, 1.0309 us/op
+WorkloadResult  14: 524288 op, 540912833.00 ns, 1.0317 us/op
+WorkloadResult  15: 524288 op, 540081577.00 ns, 1.0301 us/op
+// GC:  9 0 0 226493152 524288
+// Threading:  0 0 524288
+
+// AfterAll
+// Benchmark Process 2460 has exited with code 0.
+
+Mean = 1.023 us, StdErr = 0.002 us (0.16%), N = 15, StdDev = 0.006 us
+Min = 1.015 us, Q1 = 1.017 us, Median = 1.021 us, Q3 = 1.029 us, Max = 1.032 us
+IQR = 0.012 us, LowerFence = 0.999 us, UpperFence = 1.047 us
+ConfidenceInterval = [1.016 us; 1.030 us] (CI 99.9%), Margin = 0.007 us (0.65% of Mean)
+Skewness = 0.09, Kurtosis = 1.23, MValue = 2
+
+// ** Remained 2 (66.7 %) benchmark(s) to run. Estimated finish 2026-02-16 5:52 (0h 0m from now) **
+// **************************
+// Benchmark: BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet 7b35e4a4-627d-434a-a2d8-02bd28e71507.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.SerializeWithIntegrity --job Default --benchmarkId 1 in /app/Benchmarks/bin/Release/net8.0/7b35e4a4-627d-434a-a2d8-02bd28e71507/bin/Release/net8.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.13.12
+// Runtime=.NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 455257.00 ns, 455.2570 us/op
+WorkloadJitting  1: 1 op, 706318.00 ns, 706.3180 us/op
+
+OverheadJitting  2: 16 op, 294519.00 ns, 18.4074 us/op
+WorkloadJitting  2: 16 op, 566694.00 ns, 35.4184 us/op
+
+WorkloadPilot    1: 16 op, 261514.00 ns, 16.3446 us/op
+WorkloadPilot    2: 32 op, 382093.00 ns, 11.9404 us/op
+WorkloadPilot    3: 64 op, 698298.00 ns, 10.9109 us/op
+WorkloadPilot    4: 128 op, 1279140.00 ns, 9.9933 us/op
+WorkloadPilot    5: 256 op, 2462842.00 ns, 9.6205 us/op
+WorkloadPilot    6: 512 op, 4878610.00 ns, 9.5285 us/op
+WorkloadPilot    7: 1024 op, 9593769.00 ns, 9.3689 us/op
+WorkloadPilot    8: 2048 op, 19112852.00 ns, 9.3324 us/op
+WorkloadPilot    9: 4096 op, 38603382.00 ns, 9.4247 us/op
+WorkloadPilot   10: 8192 op, 79824400.00 ns, 9.7442 us/op
+WorkloadPilot   11: 16384 op, 192933532.00 ns, 11.7757 us/op
+WorkloadPilot   12: 32768 op, 268842633.00 ns, 8.2044 us/op
+WorkloadPilot   13: 65536 op, 363967189.00 ns, 5.5537 us/op
+WorkloadPilot   14: 131072 op, 709882104.00 ns, 5.4160 us/op
+
+OverheadWarmup   1: 131072 op, 437800.00 ns, 3.3401 ns/op
+OverheadWarmup   2: 131072 op, 402174.00 ns, 3.0683 ns/op
+OverheadWarmup   3: 131072 op, 438580.00 ns, 3.3461 ns/op
+OverheadWarmup   4: 131072 op, 408495.00 ns, 3.1166 ns/op
+OverheadWarmup   5: 131072 op, 471515.00 ns, 3.5974 ns/op
+OverheadWarmup   6: 131072 op, 402283.00 ns, 3.0692 ns/op
+
+OverheadActual   1: 131072 op, 449289.00 ns, 3.4278 ns/op
+OverheadActual   2: 131072 op, 435370.00 ns, 3.3216 ns/op
+OverheadActual   3: 131072 op, 460452.00 ns, 3.5130 ns/op
+OverheadActual   4: 131072 op, 425498.00 ns, 3.2463 ns/op
+OverheadActual   5: 131072 op, 417786.00 ns, 3.1875 ns/op
+OverheadActual   6: 131072 op, 448045.00 ns, 3.4183 ns/op
+OverheadActual   7: 131072 op, 434693.00 ns, 3.3164 ns/op
+OverheadActual   8: 131072 op, 439420.00 ns, 3.3525 ns/op
+OverheadActual   9: 131072 op, 445616.00 ns, 3.3998 ns/op
+OverheadActual  10: 131072 op, 435510.00 ns, 3.3227 ns/op
+OverheadActual  11: 131072 op, 479907.00 ns, 3.6614 ns/op
+OverheadActual  12: 131072 op, 402139.00 ns, 3.0681 ns/op
+OverheadActual  13: 131072 op, 454481.00 ns, 3.4674 ns/op
+OverheadActual  14: 131072 op, 402259.00 ns, 3.0690 ns/op
+OverheadActual  15: 131072 op, 404116.00 ns, 3.0832 ns/op
+OverheadActual  16: 131072 op, 412888.00 ns, 3.1501 ns/op
+OverheadActual  17: 131072 op, 436497.00 ns, 3.3302 ns/op
+
+WorkloadWarmup   1: 131072 op, 734571637.00 ns, 5.6043 us/op
+WorkloadWarmup   2: 131072 op, 726515525.00 ns, 5.5429 us/op
+WorkloadWarmup   3: 131072 op, 715558464.00 ns, 5.4593 us/op
+WorkloadWarmup   4: 131072 op, 714961138.00 ns, 5.4547 us/op
+WorkloadWarmup   5: 131072 op, 739836979.00 ns, 5.6445 us/op
+WorkloadWarmup   6: 131072 op, 714470675.00 ns, 5.4510 us/op
+WorkloadWarmup   7: 131072 op, 712261864.00 ns, 5.4341 us/op
+WorkloadWarmup   8: 131072 op, 709733266.00 ns, 5.4148 us/op
+WorkloadWarmup   9: 131072 op, 711102637.00 ns, 5.4253 us/op
+WorkloadWarmup  10: 131072 op, 709525146.00 ns, 5.4132 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 131072 op, 709395650.00 ns, 5.4123 us/op
+WorkloadActual   2: 131072 op, 709320702.00 ns, 5.4117 us/op
+WorkloadActual   3: 131072 op, 706667725.00 ns, 5.3914 us/op
+WorkloadActual   4: 131072 op, 707680178.00 ns, 5.3992 us/op
+WorkloadActual   5: 131072 op, 708164164.00 ns, 5.4029 us/op
+WorkloadActual   6: 131072 op, 711721353.00 ns, 5.4300 us/op
+WorkloadActual   7: 131072 op, 711054892.00 ns, 5.4249 us/op
+WorkloadActual   8: 131072 op, 722741385.00 ns, 5.5141 us/op
+WorkloadActual   9: 131072 op, 718908172.00 ns, 5.4848 us/op
+WorkloadActual  10: 131072 op, 720958444.00 ns, 5.5005 us/op
+WorkloadActual  11: 131072 op, 722781882.00 ns, 5.5144 us/op
+WorkloadActual  12: 131072 op, 719547152.00 ns, 5.4897 us/op
+WorkloadActual  13: 131072 op, 725038088.00 ns, 5.5316 us/op
+WorkloadActual  14: 131072 op, 706456119.00 ns, 5.3898 us/op
+WorkloadActual  15: 131072 op, 711808181.00 ns, 5.4307 us/op
+
+// AfterActualRun
+WorkloadResult   1: 131072 op, 708960140.00 ns, 5.4089 us/op
+WorkloadResult   2: 131072 op, 708885192.00 ns, 5.4084 us/op
+WorkloadResult   3: 131072 op, 706232215.00 ns, 5.3881 us/op
+WorkloadResult   4: 131072 op, 707244668.00 ns, 5.3958 us/op
+WorkloadResult   5: 131072 op, 707728654.00 ns, 5.3995 us/op
+WorkloadResult   6: 131072 op, 711285843.00 ns, 5.4267 us/op
+WorkloadResult   7: 131072 op, 710619382.00 ns, 5.4216 us/op
+WorkloadResult   8: 131072 op, 722305875.00 ns, 5.5108 us/op
+WorkloadResult   9: 131072 op, 718472662.00 ns, 5.4815 us/op
+WorkloadResult  10: 131072 op, 720522934.00 ns, 5.4972 us/op
+WorkloadResult  11: 131072 op, 722346372.00 ns, 5.5111 us/op
+WorkloadResult  12: 131072 op, 719111642.00 ns, 5.4864 us/op
+WorkloadResult  13: 131072 op, 724602578.00 ns, 5.5283 us/op
+WorkloadResult  14: 131072 op, 706020609.00 ns, 5.3865 us/op
+WorkloadResult  15: 131072 op, 711372671.00 ns, 5.4273 us/op
+// GC:  2 0 0 60818144 131072
+// Threading:  0 0 131072
+
+// AfterAll
+// Benchmark Process 2472 has exited with code 0.
+
+Mean = 5.445 us, StdErr = 0.013 us (0.24%), N = 15, StdDev = 0.051 us
+Min = 5.387 us, Q1 = 5.404 us, Median = 5.427 us, Q3 = 5.492 us, Max = 5.528 us
+IQR = 0.088 us, LowerFence = 5.272 us, UpperFence = 5.623 us
+ConfidenceInterval = [5.391 us; 5.500 us] (CI 99.9%), Margin = 0.054 us (1.00% of Mean)
+Skewness = 0.34, Kurtosis = 1.32, MValue = 2
+
+// ** Remained 1 (33.3 %) benchmark(s) to run. Estimated finish 2026-02-16 5:52 (0h 0m from now) **
+// **************************
+// Benchmark: BinaryPacketBenchmark.DeserializeWithIntegrity: DefaultJob
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet 7b35e4a4-627d-434a-a2d8-02bd28e71507.dll --anonymousPipes 119 120 --benchmarkName Benchmarks.BinaryPacketBenchmark.DeserializeWithIntegrity --job Default --benchmarkId 2 in /app/Benchmarks/bin/Release/net8.0/7b35e4a4-627d-434a-a2d8-02bd28e71507/bin/Release/net8.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.13.12
+// Runtime=.NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2,AES,BMI1,BMI2,FMA,LZCNT,PCLMUL,POPCNT VectorSize=256
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 437469.00 ns, 437.4690 us/op
+WorkloadJitting  1: 1 op, 7041023.00 ns, 7.0410 ms/op
+
+OverheadJitting  2: 16 op, 323558.00 ns, 20.2224 us/op
+WorkloadJitting  2: 16 op, 774346.00 ns, 48.3966 us/op
+
+WorkloadPilot    1: 16 op, 267883.00 ns, 16.7427 us/op
+WorkloadPilot    2: 32 op, 532539.00 ns, 16.6418 us/op
+WorkloadPilot    3: 64 op, 972708.00 ns, 15.1986 us/op
+WorkloadPilot    4: 128 op, 1668153.00 ns, 13.0324 us/op
+WorkloadPilot    5: 256 op, 3280663.00 ns, 12.8151 us/op
+WorkloadPilot    6: 512 op, 7027083.00 ns, 13.7248 us/op
+WorkloadPilot    7: 1024 op, 13473578.00 ns, 13.1578 us/op
+WorkloadPilot    8: 2048 op, 28728982.00 ns, 14.0278 us/op
+WorkloadPilot    9: 4096 op, 51741957.00 ns, 12.6323 us/op
+WorkloadPilot   10: 8192 op, 145795658.00 ns, 17.7973 us/op
+WorkloadPilot   11: 16384 op, 268092256.00 ns, 16.3631 us/op
+WorkloadPilot   12: 32768 op, 260240802.00 ns, 7.9419 us/op
+WorkloadPilot   13: 65536 op, 451946415.00 ns, 6.8962 us/op
+WorkloadPilot   14: 131072 op, 893374470.00 ns, 6.8159 us/op
+
+OverheadWarmup   1: 131072 op, 403640.00 ns, 3.0795 ns/op
+OverheadWarmup   2: 131072 op, 441262.00 ns, 3.3666 ns/op
+OverheadWarmup   3: 131072 op, 440250.00 ns, 3.3588 ns/op
+OverheadWarmup   4: 131072 op, 449259.00 ns, 3.4276 ns/op
+OverheadWarmup   5: 131072 op, 439670.00 ns, 3.3544 ns/op
+
+OverheadActual   1: 131072 op, 402915.00 ns, 3.0740 ns/op
+OverheadActual   2: 131072 op, 402884.00 ns, 3.0738 ns/op
+OverheadActual   3: 131072 op, 402889.00 ns, 3.0738 ns/op
+OverheadActual   4: 131072 op, 440771.00 ns, 3.3628 ns/op
+OverheadActual   5: 131072 op, 438918.00 ns, 3.3487 ns/op
+OverheadActual   6: 131072 op, 436789.00 ns, 3.3324 ns/op
+OverheadActual   7: 131072 op, 402635.00 ns, 3.0719 ns/op
+OverheadActual   8: 131072 op, 402585.00 ns, 3.0715 ns/op
+OverheadActual   9: 131072 op, 402412.00 ns, 3.0702 ns/op
+OverheadActual  10: 131072 op, 409217.00 ns, 3.1221 ns/op
+OverheadActual  11: 131072 op, 407430.00 ns, 3.1084 ns/op
+OverheadActual  12: 131072 op, 402614.00 ns, 3.0717 ns/op
+OverheadActual  13: 131072 op, 404388.00 ns, 3.0852 ns/op
+OverheadActual  14: 131072 op, 445438.00 ns, 3.3984 ns/op
+OverheadActual  15: 131072 op, 451994.00 ns, 3.4484 ns/op
+
+WorkloadWarmup   1: 131072 op, 904383567.00 ns, 6.8999 us/op
+WorkloadWarmup   2: 131072 op, 901050249.00 ns, 6.8745 us/op
+WorkloadWarmup   3: 131072 op, 888167784.00 ns, 6.7762 us/op
+WorkloadWarmup   4: 131072 op, 885928724.00 ns, 6.7591 us/op
+WorkloadWarmup   5: 131072 op, 888660260.00 ns, 6.7799 us/op
+WorkloadWarmup   6: 131072 op, 892506958.00 ns, 6.8093 us/op
+WorkloadWarmup   7: 131072 op, 890804435.00 ns, 6.7963 us/op
+WorkloadWarmup   8: 131072 op, 889493449.00 ns, 6.7863 us/op
+WorkloadWarmup   9: 131072 op, 915774849.00 ns, 6.9868 us/op
+WorkloadWarmup  10: 131072 op, 888944279.00 ns, 6.7821 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 131072 op, 890216239.00 ns, 6.7918 us/op
+WorkloadActual   2: 131072 op, 882097282.00 ns, 6.7299 us/op
+WorkloadActual   3: 131072 op, 874425616.00 ns, 6.6713 us/op
+WorkloadActual   4: 131072 op, 882726028.00 ns, 6.7347 us/op
+WorkloadActual   5: 131072 op, 878929414.00 ns, 6.7057 us/op
+WorkloadActual   6: 131072 op, 875483181.00 ns, 6.6794 us/op
+WorkloadActual   7: 131072 op, 875449714.00 ns, 6.6792 us/op
+WorkloadActual   8: 131072 op, 882365040.00 ns, 6.7319 us/op
+WorkloadActual   9: 131072 op, 882518647.00 ns, 6.7331 us/op
+WorkloadActual  10: 131072 op, 877550331.00 ns, 6.6952 us/op
+WorkloadActual  11: 131072 op, 880249387.00 ns, 6.7158 us/op
+WorkloadActual  12: 131072 op, 881039479.00 ns, 6.7218 us/op
+WorkloadActual  13: 131072 op, 879875762.00 ns, 6.7129 us/op
+WorkloadActual  14: 131072 op, 882621745.00 ns, 6.7339 us/op
+WorkloadActual  15: 131072 op, 882692105.00 ns, 6.7344 us/op
+
+// AfterActualRun
+WorkloadResult   1: 131072 op, 881692894.00 ns, 6.7268 us/op
+WorkloadResult   2: 131072 op, 874021228.00 ns, 6.6683 us/op
+WorkloadResult   3: 131072 op, 882321640.00 ns, 6.7316 us/op
+WorkloadResult   4: 131072 op, 878525026.00 ns, 6.7026 us/op
+WorkloadResult   5: 131072 op, 875078793.00 ns, 6.6763 us/op
+WorkloadResult   6: 131072 op, 875045326.00 ns, 6.6761 us/op
+WorkloadResult   7: 131072 op, 881960652.00 ns, 6.7288 us/op
+WorkloadResult   8: 131072 op, 882114259.00 ns, 6.7300 us/op
+WorkloadResult   9: 131072 op, 877145943.00 ns, 6.6921 us/op
+WorkloadResult  10: 131072 op, 879844999.00 ns, 6.7127 us/op
+WorkloadResult  11: 131072 op, 880635091.00 ns, 6.7187 us/op
+WorkloadResult  12: 131072 op, 879471374.00 ns, 6.7098 us/op
+WorkloadResult  13: 131072 op, 882217357.00 ns, 6.7308 us/op
+WorkloadResult  14: 131072 op, 882287717.00 ns, 6.7313 us/op
+// GC:  4 0 0 95421152 131072
+// Threading:  0 0 131072
+
+// AfterAll
+// Benchmark Process 2485 has exited with code 0.
+
+Mean = 6.710 us, StdErr = 0.006 us (0.09%), N = 14, StdDev = 0.023 us
+Min = 6.668 us, Q1 = 6.695 us, Median = 6.716 us, Q3 = 6.730 us, Max = 6.732 us
+IQR = 0.035 us, LowerFence = 6.642 us, UpperFence = 6.782 us
+ConfidenceInterval = [6.684 us; 6.736 us] (CI 99.9%), Margin = 0.026 us (0.39% of Mean)
+Skewness = -0.6, Kurtosis = 1.69, MValue = 2
+
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-02-16 5:52 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkDotNet.Artifacts/results/Benchmarks.BinaryPacketBenchmark-report.csv
+  BenchmarkDotNet.Artifacts/results/Benchmarks.BinaryPacketBenchmark-report-github.md
+  BenchmarkDotNet.Artifacts/results/Benchmarks.BinaryPacketBenchmark-report.html
+
+// * Detailed results *
+BinaryPacketBenchmark.SerializeToWriter: DefaultJob
+Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 1.023 us, StdErr = 0.002 us (0.16%), N = 15, StdDev = 0.006 us
+Min = 1.015 us, Q1 = 1.017 us, Median = 1.021 us, Q3 = 1.029 us, Max = 1.032 us
+IQR = 0.012 us, LowerFence = 0.999 us, UpperFence = 1.047 us
+ConfidenceInterval = [1.016 us; 1.030 us] (CI 99.9%), Margin = 0.007 us (0.65% of Mean)
+Skewness = 0.09, Kurtosis = 1.23, MValue = 2
+-------------------- Histogram --------------------
+[1.012 us ; 1.035 us) | @@@@@@@@@@@@@@@
+---------------------------------------------------
+
+BinaryPacketBenchmark.SerializeWithIntegrity: DefaultJob
+Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 5.445 us, StdErr = 0.013 us (0.24%), N = 15, StdDev = 0.051 us
+Min = 5.387 us, Q1 = 5.404 us, Median = 5.427 us, Q3 = 5.492 us, Max = 5.528 us
+IQR = 0.088 us, LowerFence = 5.272 us, UpperFence = 5.623 us
+ConfidenceInterval = [5.391 us; 5.500 us] (CI 99.9%), Margin = 0.054 us (1.00% of Mean)
+Skewness = 0.34, Kurtosis = 1.32, MValue = 2
+-------------------- Histogram --------------------
+[5.359 us ; 5.555 us) | @@@@@@@@@@@@@@@
+---------------------------------------------------
+
+BinaryPacketBenchmark.DeserializeWithIntegrity: DefaultJob
+Runtime = .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2; GC = Concurrent Workstation
+Mean = 6.710 us, StdErr = 0.006 us (0.09%), N = 14, StdDev = 0.023 us
+Min = 6.668 us, Q1 = 6.695 us, Median = 6.716 us, Q3 = 6.730 us, Max = 6.732 us
+IQR = 0.035 us, LowerFence = 6.642 us, UpperFence = 6.782 us
+ConfidenceInterval = [6.684 us; 6.736 us] (CI 99.9%), Margin = 0.026 us (0.39% of Mean)
+Skewness = -0.6, Kurtosis = 1.69, MValue = 2
+-------------------- Histogram --------------------
+[6.656 us ; 6.744 us) | @@@@@@@@@@@@@@
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.13.12, Ubuntu 24.04.3 LTS (Noble Numbat)
+Intel Xeon Processor 2.30GHz, 1 CPU, 4 logical and 4 physical cores
+.NET SDK 10.0.100
+  [Host]     : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.22 (8.0.2225.52707), X64 RyuJIT AVX2
+
+
+| Method                   | Mean     | Error     | StdDev    | Gen0   | Allocated |
+|------------------------- |---------:|----------:|----------:|-------:|----------:|
+| SerializeToWriter        | 1.023 us | 0.0067 us | 0.0062 us | 0.0172 |     432 B |
+| SerializeWithIntegrity   | 5.445 us | 0.0545 us | 0.0510 us | 0.0153 |     464 B |
+| DeserializeWithIntegrity | 6.710 us | 0.0259 us | 0.0230 us | 0.0305 |     728 B |
+
+// * Hints *
+Outliers
+  BinaryPacketBenchmark.DeserializeWithIntegrity: Default -> 1 outlier  was  removed (6.79 us)
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Gen0      : GC Generation 0 collects per 1000 operations
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 us      : 1 Microsecond (0.000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:01:04 (64.26 sec), executed benchmarks: 3
+
+Global total time: 00:01:14 (74.54 sec), executed benchmarks: 3
+// * Artifacts cleanup *
+Artifacts cleanup is finished


### PR DESCRIPTION
💡 What: Optimized `BinaryPacket.SerializeToWriter` to avoid temporary `byte[]` allocations when serializing JSON payloads for encryption or integrity checks.
🎯 Why: `JsonSerializer.SerializeToUtf8Bytes` allocates a new byte array every time, which increases GC pressure.
📊 Impact: Reduces memory allocation by ~10% for small payloads (56 bytes saved per op) and eliminates payload-sized allocations for larger messages.
🔬 Measurement: Validated using `BinaryPacketBenchmark`. `SerializeWithIntegrity` allocation dropped from 520B to 464B.


---
*PR created automatically by Jules for task [2363804813836466538](https://jules.google.com/task/2363804813836466538) started by @jhincapie*