### PR TITLE
🛡️ Sentinel: Add HMAC-SHA256 Message Integrity Check

### DIFF
--- a/MulticastTransportFramework/SecurityHandler.cs
+++ b/MulticastTransportFramework/SecurityHandler.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Ubicomp.Utils.NET.MulticastTransportFramework
+{
+    internal static class SecurityHandler
+    {
+        public static string ComputeHash(TransportMessage msg, byte[] key, JsonSerializerOptions options)
+        {
+            string dataJson;
+            if (msg.MessageData is JsonElement element)
+            {
+                dataJson = element.GetRawText();
+            }
+            else
+            {
+                dataJson = JsonSerializer.Serialize(msg.MessageData, options);
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(msg.MessageId);
+            sb.Append('|');
+            sb.Append(msg.TimeStamp);
+            sb.Append('|');
+            sb.Append(msg.MessageType);
+            sb.Append('|');
+            if (msg.MessageSource != null)
+            {
+                sb.Append(msg.MessageSource.ResourceId);
+            }
+            sb.Append('|');
+            sb.Append(msg.RequestAck);
+            sb.Append('|');
+            sb.Append(dataJson);
+
+            using (var hmac = new HMACSHA256(key))
+            {
+                byte[] hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(sb.ToString()));
+                return Convert.ToBase64String(hash);
+            }
+        }
+
+        public static bool VerifyHash(TransportMessage msg, byte[] key, JsonSerializerOptions options)
+        {
+            if (string.IsNullOrEmpty(msg.Hash)) return false;
+
+            string computed = ComputeHash(msg, key, options);
+
+            return FixedTimeEquals(msg.Hash, computed);
+        }
+
+        private static bool FixedTimeEquals(string left, string right)
+        {
+            if (left.Length != right.Length) return false;
+
+            int diff = 0;
+            for (int i = 0; i < left.Length; i++)
+            {
+                diff |= left[i] ^ right[i];
+            }
+            return diff == 0;
+        }
+    }
+}

--- a/MulticastTransportFramework/TransportBuilder.cs
+++ b/MulticastTransportFramework/TransportBuilder.cs
@@ -14,6 +14,7 @@ namespace Ubicomp.Utils.NET.MulticastTransportFramework
         private MulticastSocketOptions? _options;
         private ILoggerFactory? _loggerFactory;
         private EventSource? _localSource;
+        private string? _securityKey;
         private bool _autoSendAcks = false;
         private bool? _enforceOrdering;
         private readonly List<Action<TransportComponent>> _registrations = new List<Action<TransportComponent>>();
@@ -51,6 +52,15 @@ namespace Ubicomp.Utils.NET.MulticastTransportFramework
         public TransportBuilder WithLocalSource(string resourceName, Guid? resourceId = null)
         {
             _localSource = new EventSource(resourceId ?? Guid.NewGuid(), resourceName);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the security key for message signing.
+        /// </summary>
+        public TransportBuilder WithSecurityKey(string key)
+        {
+            _securityKey = key;
             return this;
         }
 
@@ -104,6 +114,11 @@ namespace Ubicomp.Utils.NET.MulticastTransportFramework
             if (_localSource != null)
             {
                 component.LocalSource = _localSource;
+            }
+
+            if (_securityKey != null)
+            {
+                component.SetSecurityKey(_securityKey);
             }
 
             component.AutoSendAcks = _autoSendAcks;

--- a/MulticastTransportFramework/TransportMessage.cs
+++ b/MulticastTransportFramework/TransportMessage.cs
@@ -45,6 +45,10 @@ namespace Ubicomp.Utils.NET.MulticastTransportFramework
         /// <summary>Gets or sets the message timestamp.</summary>
         public string TimeStamp { get; set; } = string.Empty;
 
+        /// <summary>Gets or sets the integrity hash of the message.</summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Hash { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TransportMessage"/>
         /// class.

--- a/Tests/IntegrityTests.cs
+++ b/Tests/IntegrityTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Text;
+using System.Threading;
+using Ubicomp.Utils.NET.MulticastTransportFramework;
+using Ubicomp.Utils.NET.Sockets;
+using Xunit;
+
+namespace Ubicomp.Utils.NET.Tests
+{
+    [Collection("SharedTransport")]
+    public class IntegrityTests
+    {
+        [MessageType("test.integrity")]
+        private class IntegrityContent
+        {
+            public string Data { get; set; } = "";
+        }
+
+        [Fact]
+        public void Receive_SignedMessage_WhenKeyIsSet_AcceptsMessage()
+        {
+            // Arrange
+            // Use unique ports
+            var options = MulticastSocketOptions.LocalNetwork("239.0.0.1", 5010);
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                options.LocalIP = "127.0.0.1";
+            }
+            string key = "super_secret_key";
+
+            var receivedEvent = new ManualResetEventSlim(false);
+
+            var transport = new TransportBuilder()
+                .WithMulticastOptions(options)
+                .WithSecurityKey(key)
+                .RegisterHandler<IntegrityContent>((content, context) =>
+                {
+                    receivedEvent.Set();
+                })
+                .Build();
+
+            transport.Start();
+
+            try
+            {
+                // Act
+                // We send using the same transport (loopback) which will sign it
+                var content = new IntegrityContent { Data = "Valid" };
+                transport.SendAsync(content).Wait();
+
+                // Assert
+                bool received = receivedEvent.Wait(2000);
+                Assert.True(received, "Signed message should be accepted");
+            }
+            finally
+            {
+                transport.Stop();
+            }
+        }
+
+        [Fact]
+        public void Receive_UnsignedMessage_WhenKeyIsSet_DropsMessage()
+        {
+            // Arrange
+            var options = MulticastSocketOptions.LocalNetwork("239.0.0.1", 5011);
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                options.LocalIP = "127.0.0.1";
+            }
+            string key = "super_secret_key";
+
+            var receivedEvent = new ManualResetEventSlim(false);
+
+            var transport = new TransportBuilder()
+                .WithMulticastOptions(options)
+                .WithSecurityKey(key)
+                .RegisterHandler<IntegrityContent>((content, context) =>
+                {
+                    receivedEvent.Set();
+                })
+                .Build();
+
+            transport.Start();
+
+            try
+            {
+                // Manually construct an unsigned message
+                var messageId = Guid.NewGuid();
+                var timeStamp = DateTime.UtcNow.ToString(TransportMessage.DATE_FORMAT_NOW);
+                var json = $@"{{
+                    ""messageId"": ""{messageId}"",
+                    ""messageType"": ""test.integrity"",
+                    ""messageSource"": {{ ""resourceId"": ""{Guid.NewGuid()}"", ""resourceName"": ""attacker"" }},
+                    ""timeStamp"": ""{timeStamp}"",
+                    ""messageData"": {{ ""data"": ""Valid"" }}
+                }}";
+                // Note: No 'hash' field
+
+                var bytes = Encoding.UTF8.GetBytes(json);
+                var socketMsg = new SocketMessage(bytes, 1);
+
+                // Act
+                transport.HandleSocketMessage(socketMsg);
+
+                // Assert
+                bool received = receivedEvent.Wait(2000);
+                Assert.False(received, "Unsigned message should be dropped");
+            }
+            finally
+            {
+                transport.Stop();
+            }
+        }
+
+        [Fact]
+        public void Receive_InvalidSignature_WhenKeyIsSet_DropsMessage()
+        {
+            // Arrange
+            var options = MulticastSocketOptions.LocalNetwork("239.0.0.1", 5012);
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                options.LocalIP = "127.0.0.1";
+            }
+            string key = "super_secret_key";
+
+            var receivedEvent = new ManualResetEventSlim(false);
+
+            var transport = new TransportBuilder()
+                .WithMulticastOptions(options)
+                .WithSecurityKey(key)
+                .RegisterHandler<IntegrityContent>((content, context) =>
+                {
+                    receivedEvent.Set();
+                })
+                .Build();
+
+            transport.Start();
+
+            try
+            {
+                // Manually construct message with fake hash
+                var messageId = Guid.NewGuid();
+                var timeStamp = DateTime.UtcNow.ToString(TransportMessage.DATE_FORMAT_NOW);
+                var json = $@"{{
+                    ""messageId"": ""{messageId}"",
+                    ""messageType"": ""test.integrity"",
+                    ""messageSource"": {{ ""resourceId"": ""{Guid.NewGuid()}"", ""resourceName"": ""attacker"" }},
+                    ""timeStamp"": ""{timeStamp}"",
+                    ""hash"": ""ZmFrZWhhc2g="",
+                    ""messageData"": {{ ""data"": ""Valid"" }}
+                }}";
+
+                var bytes = Encoding.UTF8.GetBytes(json);
+                var socketMsg = new SocketMessage(bytes, 1);
+
+                // Act
+                transport.HandleSocketMessage(socketMsg);
+
+                // Assert
+                bool received = receivedEvent.Wait(2000);
+                Assert.False(received, "Invalid signature message should be dropped");
+            }
+            finally
+            {
+                transport.Stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add HMAC-SHA256 Integrity Check

**Severity:** HIGH (Enhancement)
**Vulnerability:** Lack of message integrity verification allowed potential spoofing of multicast messages.
**Impact:** Attackers on the local network could forge messages (e.g., `sys.ack` or command messages) appearing to be from legitimate sources.
**Fix:** Implemented optional HMAC-SHA256 signing.
- Added `SecurityHandler` to compute and verify signatures.
- Added `Hash` field to `TransportMessage` envelope.
- Enforced signature verification in `TransportComponent` when a key is set.
- Used constant-time comparison to prevent timing attacks.

**Verification:**
- Run `dotnet test Tests/Ubicomp.Utils.NET.Tests.csproj --filter "IntegrityTests"` to verify signing and rejection logic.
- Existing tests pass (ignoring known flaky `SocketOptionsTests`).

---
*PR created automatically by Jules for task [15239766420903123260](https://jules.google.com/task/15239766420903123260) started by @jhincapie*